### PR TITLE
Add footer section to home page

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -1,0 +1,91 @@
+.footer {
+    margin-top: 80px;
+    padding: 48px 6vw 28px;
+    background: linear-gradient(135deg, #1f2937, #111827);
+    color: #f9fafb;
+    border-radius: 28px 28px 0 0;
+    box-shadow: 0 -12px 40px rgba(15, 23, 42, 0.35);
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 32px;
+}
+
+.footer-column h4 {
+    font-size: 1.1rem;
+    margin-bottom: 16px;
+    color: tomato;
+    font-weight: 600;
+}
+
+.footer-column ul {
+    list-style: none;
+    display: grid;
+    gap: 12px;
+    padding: 0;
+}
+
+.footer-column li,
+.footer-column a {
+    font-size: 0.95rem;
+    color: rgba(249, 250, 251, 0.84);
+    line-height: 1.6;
+    transition: color 0.3s ease;
+}
+
+.footer-column a:hover {
+    color: #ffffff;
+}
+
+.footer-logo {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.footer-logo img {
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    object-fit: cover;
+    box-shadow: 0 10px 25px rgba(255, 99, 71, 0.3);
+}
+
+.footer-logo span {
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.footer-about p {
+    font-size: 0.95rem;
+    color: rgba(249, 250, 251, 0.78);
+    line-height: 1.7;
+}
+
+.footer-bottom {
+    margin-top: 40px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    text-align: center;
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+@media (max-width: 640px) {
+    .footer {
+        padding: 36px 6vw 24px;
+        border-radius: 20px 20px 0 0;
+    }
+
+    .footer-logo {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .footer-logo span {
+        font-size: 1.2rem;
+    }
+}

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,1 +1,45 @@
+import React from 'react'
+import './Footer.css'
+import { assets } from '../../assets/assets'
 
+const Footer = () => {
+    const year = new Date().getFullYear()
+
+    return (
+        <footer className='footer'>
+            <div className="footer-content">
+                <div className="footer-column footer-about">
+                    <div className="footer-logo">
+                        <img src={assets.logo} alt="FoodFast Delivery logo" />
+                        <span>FoodFast Delivery</span>
+                    </div>
+                    <p>
+                        FoodFast Delivery mang đến cho bạn trải nghiệm giao đồ ăn nhanh chóng, tiện lợi và an toàn.
+                        Chúng tôi hợp tác với những đầu bếp địa phương để phục vụ các món ăn yêu thích mọi lúc bạn cần.
+                    </p>
+                </div>
+                <div className="footer-column">
+                    <h4>Liên kết nhanh</h4>
+                    <ul>
+                        <li><a href="#explore-menu">Khám phá menu</a></li>
+                        <li><a href="#food-display">Món ăn nổi bật</a></li>
+                        <li><a href="/cart">Giỏ hàng của bạn</a></li>
+                    </ul>
+                </div>
+                <div className="footer-column">
+                    <h4>Liên hệ</h4>
+                    <ul>
+                        <li>Hotline: 1900 0099</li>
+                        <li>Email: support@foodfast.vn</li>
+                        <li>Địa chỉ: 123 Phố Ẩm Thực, Q.1, TP.HCM</li>
+                    </ul>
+                </div>
+            </div>
+            <div className="footer-bottom">
+                <span>© {year} FoodFast Delivery. Tất cả các quyền được bảo lưu.</span>
+            </div>
+        </footer>
+    )
+}
+
+export default Footer

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,6 +3,7 @@ import './Home.css'
 import Header from '../../components/Header/Header'
 import ExploreMenu from '../../components/ExploreMenu/ExploreMenu'
 import FoodDisplay from '../../components/FoodDisplay/FoodDisplay'
+import Footer from '../../components/Footer/Footer'
 
 const Home = () => {
 
@@ -13,6 +14,7 @@ const Home = () => {
             <Header />
             <ExploreMenu category={category} setCategory={setCategory} />
             <FoodDisplay category={category} />
+            <Footer />
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- create a footer component with brand, quick links, and contact information for the landing page
- add gradient styling and responsive layout rules for the new footer section
- render the footer on the home page so it appears across the main content

## Testing
- npm run lint *(fails: pre-existing issues in StoreContext.jsx and FoodItem.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68eeb3e21208832f85e6ac34b2a5a21b