### PR TITLE
Add language toggle to footer

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -69,15 +69,50 @@
     margin-top: 40px;
     padding-top: 16px;
     border-top: 1px solid rgba(148, 163, 184, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: center;
+    justify-content: center;
     text-align: center;
     font-size: 0.9rem;
     color: rgba(226, 232, 240, 0.7);
+}
+
+.footer-language-switch {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 999px;
+    padding: 8px 16px;
+    color: #f9fafb;
+    font-size: 0.9rem;
+}
+
+.footer-language-switch select {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    outline: none;
+}
+
+.footer-language-switch option {
+    color: #111827;
 }
 
 @media (max-width: 640px) {
     .footer {
         padding: 36px 6vw 24px;
         border-radius: 20px 20px 0 0;
+    }
+
+    .footer-bottom {
+        gap: 12px;
     }
 
     .footer-logo {

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,9 +1,57 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import './Footer.css'
 import { assets } from '../../assets/assets'
 
 const Footer = () => {
     const year = new Date().getFullYear()
+    const [language, setLanguage] = useState('vi')
+
+    const translations = useMemo(() => ({
+        vi: {
+            description: 'FoodFast Delivery mang đến cho bạn trải nghiệm giao đồ ăn nhanh chóng, tiện lợi và an toàn. Chúng tôi hợp tác với những đầu bếp địa phương để phục vụ các món ăn yêu thích mọi lúc bạn cần.',
+            quickLinksTitle: 'Liên kết nhanh',
+            quickLinks: [
+                { href: '#explore-menu', label: 'Khám phá menu' },
+                { href: '#food-display', label: 'Món ăn nổi bật' },
+                { href: '/cart', label: 'Giỏ hàng của bạn' }
+            ],
+            contactTitle: 'Liên hệ',
+            contactItems: [
+                'Hotline: 1111111111',
+                'Email: support@foodfast.vn',
+                'Địa chỉ: 273 An Dương Vương, Phường Chợ Quán, Hồ Chí Minh'
+            ],
+            languageLabel: 'Ngôn ngữ',
+            languageOptions: {
+                vi: 'Tiếng Việt',
+                en: 'English'
+            },
+            footerNotice: `© ${year} FoodFast Delivery. Tất cả các quyền được bảo lưu.`
+        },
+        en: {
+            description: 'FoodFast Delivery brings you a fast, convenient and safe food delivery experience. We partner with local chefs to serve your favourite dishes whenever you need them.',
+            quickLinksTitle: 'Quick links',
+            quickLinks: [
+                { href: '#explore-menu', label: 'Explore menu' },
+                { href: '#food-display', label: 'Featured dishes' },
+                { href: '/cart', label: 'Your cart' }
+            ],
+            contactTitle: 'Contact',
+            contactItems: [
+                'Hotline: 1111111111',
+                'Email: support@foodfast.vn',
+                'Address: 273 An Dương Vương, Ward Chợ Quán, Ho Chi Minh City'
+            ],
+            languageLabel: 'Language',
+            languageOptions: {
+                vi: 'Vietnamese',
+                en: 'English'
+            },
+            footerNotice: `© ${year} FoodFast Delivery. All rights reserved.`
+        }
+    }), [year])
+
+    const t = translations[language]
 
     return (
         <footer className='footer'>
@@ -13,30 +61,43 @@ const Footer = () => {
                         <img src={assets.logo} alt="FoodFast Delivery logo" />
                         <span>FoodFast Delivery</span>
                     </div>
-                    <p>
-                        FoodFast Delivery mang đến cho bạn trải nghiệm giao đồ ăn nhanh chóng, tiện lợi và an toàn.
-                        Chúng tôi hợp tác với những đầu bếp địa phương để phục vụ các món ăn yêu thích mọi lúc bạn cần.
-                    </p>
+                    <p>{t.description}</p>
                 </div>
                 <div className="footer-column">
-                    <h4>Liên kết nhanh</h4>
+                    <h4>{t.quickLinksTitle}</h4>
                     <ul>
-                        <li><a href="#explore-menu">Khám phá menu</a></li>
-                        <li><a href="#food-display">Món ăn nổi bật</a></li>
-                        <li><a href="/cart">Giỏ hàng của bạn</a></li>
+                        {t.quickLinks.map((link) => (
+                            <li key={link.href}>
+                                <a href={link.href}>{link.label}</a>
+                            </li>
+                        ))}
                     </ul>
                 </div>
                 <div className="footer-column">
-                    <h4>Liên hệ</h4>
+                    <h4>{t.contactTitle}</h4>
                     <ul>
-                        <li>Hotline: 1111111111</li>
-                        <li>Email: support@foodfast.vn</li>
-                        <li>Địa chỉ: 273 An Dương Vương, Phường Chợ Quán, Hồ Chí Minh</li>
+                        {t.contactItems.map((item, index) => (
+                            <li key={index}>{item}</li>
+                        ))}
                     </ul>
                 </div>
             </div>
             <div className="footer-bottom">
-                <span>© {year} FoodFast Delivery. Tất cả các quyền được bảo lưu.</span>
+                <div className="footer-language-switch">
+                    <label htmlFor="footer-language-select">{t.languageLabel}</label>
+                    <select
+                        id="footer-language-select"
+                        value={language}
+                        onChange={(event) => setLanguage(event.target.value)}
+                    >
+                        {Object.entries(t.languageOptions).map(([value, label]) => (
+                            <option key={value} value={value}>
+                                {label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <span>{t.footerNotice}</span>
             </div>
         </footer>
     )


### PR DESCRIPTION
## Summary
- add bilingual content for the footer and allow switching between Vietnamese and English
- style the footer language selector to match the existing design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eed0248fbc832f938249a554ad39f0