### PR TITLE
feat: add standalone admin dashboard

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -1,0 +1,378 @@
+const state = {
+  orders: [
+    {
+      id: 'DH-1024',
+      customer: 'Nguyễn Văn A',
+      status: 'delivering',
+      payment: 'cash',
+      amount: 320000,
+      createdAt: '2024-05-14 10:25',
+    },
+    {
+      id: 'DH-1025',
+      customer: 'Trần Thị B',
+      status: 'delivered',
+      payment: 'card',
+      amount: 215000,
+      createdAt: '2024-05-14 10:40',
+    },
+    {
+      id: 'DH-1026',
+      customer: 'Phạm Minh C',
+      status: 'delivered',
+      payment: 'cash',
+      amount: 540000,
+      createdAt: '2024-05-14 11:10',
+    },
+    {
+      id: 'DH-1027',
+      customer: 'Lê Hoàng D',
+      status: 'delivering',
+      payment: 'card',
+      amount: 189000,
+      createdAt: '2024-05-14 11:22',
+    },
+  ],
+  dishes: [
+    {
+      id: crypto.randomUUID(),
+      name: 'Cơm gà xối mỡ',
+      category: 'Món chính',
+      price: 55000,
+      status: 'available',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'Bún bò Huế',
+      category: 'Món nước',
+      price: 65000,
+      status: 'available',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'Trà đào cam sả',
+      category: 'Đồ uống',
+      price: 39000,
+      status: 'available',
+    },
+  ],
+  accounts: [
+    {
+      id: crypto.randomUUID(),
+      username: 'admin',
+      fullName: 'Quản trị viên',
+      role: 'admin',
+      status: 'active',
+    },
+    {
+      id: crypto.randomUUID(),
+      username: 'staff01',
+      fullName: 'Phan Mỹ Linh',
+      role: 'staff',
+      status: 'active',
+    },
+    {
+      id: crypto.randomUUID(),
+      username: 'staff02',
+      fullName: 'Nguyễn Thành Long',
+      role: 'staff',
+      status: 'locked',
+    },
+  ],
+  editingDishId: null,
+};
+
+const ordersTable = document.getElementById('ordersTable');
+const menuTable = document.getElementById('menuTable');
+const accountsTable = document.getElementById('accountsTable');
+const menuCount = document.getElementById('menuCount');
+
+const filterStatus = document.getElementById('filterStatus');
+const filterPayment = document.getElementById('filterPayment');
+const globalSearch = document.getElementById('globalSearch');
+
+const dishForm = document.getElementById('dishForm');
+const dishNameInput = document.getElementById('dishName');
+const dishCategoryInput = document.getElementById('dishCategory');
+const dishPriceInput = document.getElementById('dishPrice');
+const dishStatusInput = document.getElementById('dishStatus');
+const resetFormBtn = document.getElementById('resetFormBtn');
+const addDishBtn = document.getElementById('addDishBtn');
+
+const accountDialog = document.getElementById('accountDialog');
+const accountForm = document.getElementById('accountForm');
+const addAccountBtn = document.getElementById('addAccountBtn');
+const confirmDialog = document.getElementById('confirmDialog');
+const confirmMessage = document.getElementById('confirmMessage');
+const darkModeToggle = document.getElementById('darkModeToggle');
+
+const navButtons = document.querySelectorAll('.nav__item');
+const panels = document.querySelectorAll('.panel');
+
+const formatCurrency = (value) =>
+  new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(value);
+
+const createStatusPill = (value) => {
+  const span = document.createElement('span');
+  span.className = `status-pill ${value}`;
+  span.textContent =
+    {
+      delivering: 'Đang giao',
+      delivered: 'Đã giao',
+      cash: 'Tiền mặt',
+      card: 'Thẻ',
+      available: 'Đang bán',
+      out_of_stock: 'Hết hàng',
+      active: 'Hoạt động',
+      locked: 'Đã khóa',
+    }[value] || value;
+  return span;
+};
+
+function renderOrders() {
+  const statusFilter = filterStatus.value;
+  const paymentFilter = filterPayment.value;
+  const keyword = globalSearch.value.trim().toLowerCase();
+
+  const filteredOrders = state.orders.filter((order) => {
+    const matchStatus = statusFilter === 'all' || order.status === statusFilter;
+    const matchPayment = paymentFilter === 'all' || order.payment === paymentFilter;
+    const matchKeyword =
+      !keyword ||
+      order.id.toLowerCase().includes(keyword) ||
+      order.customer.toLowerCase().includes(keyword);
+    return matchStatus && matchPayment && matchKeyword;
+  });
+
+  ordersTable.replaceChildren(
+    ...filteredOrders.map((order) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${order.id}</td>
+        <td>${order.customer}</td>
+        <td></td>
+        <td></td>
+        <td>${formatCurrency(order.amount)}</td>
+        <td>${order.createdAt}</td>
+      `;
+
+      row.children[2].appendChild(createStatusPill(order.status));
+      row.children[3].appendChild(createStatusPill(order.payment));
+      return row;
+    }),
+  );
+}
+
+function renderDishes() {
+  menuCount.textContent = `${state.dishes.length} món`;
+
+  menuTable.replaceChildren(
+    ...state.dishes.map((dish) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${dish.name}</td>
+        <td>${dish.category}</td>
+        <td>${formatCurrency(dish.price)}</td>
+        <td></td>
+        <td class="col-actions">
+          <div class="table-actions">
+            <button type="button" data-action="edit" data-id="${dish.id}">Sửa</button>
+            <button type="button" class="delete" data-action="delete" data-id="${dish.id}">Xóa</button>
+          </div>
+        </td>
+      `;
+      row.children[3].appendChild(createStatusPill(dish.status));
+      return row;
+    }),
+  );
+}
+
+function renderAccounts() {
+  accountsTable.replaceChildren(
+    ...state.accounts.map((account) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${account.username}</td>
+        <td>${account.fullName}</td>
+        <td>${account.role === 'admin' ? 'Quản trị' : 'Nhân viên'}</td>
+        <td></td>
+        <td class="col-actions">
+          <div class="table-actions">
+            <button type="button" data-action="toggle" data-id="${account.id}">
+              ${account.status === 'active' ? 'Khóa' : 'Mở khóa'}
+            </button>
+            <button type="button" class="delete" data-action="delete" data-id="${account.id}">
+              Xóa
+            </button>
+          </div>
+        </td>
+      `;
+      row.children[3].appendChild(createStatusPill(account.status));
+      return row;
+    }),
+  );
+}
+
+function switchPanel(targetId) {
+  navButtons.forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.target === targetId);
+  });
+  panels.forEach((panel) => {
+    panel.classList.toggle('active', panel.id === targetId);
+  });
+}
+
+navButtons.forEach((button) => {
+  button.addEventListener('click', () => switchPanel(button.dataset.target));
+});
+
+filterStatus.addEventListener('change', renderOrders);
+filterPayment.addEventListener('change', renderOrders);
+globalSearch.addEventListener('input', () => {
+  renderOrders();
+  renderDishes();
+  renderAccounts();
+});
+
+function resetDishForm() {
+  dishForm.reset();
+  state.editingDishId = null;
+  dishForm.querySelector('button[type="submit"]').textContent = 'Lưu món';
+}
+
+addDishBtn.addEventListener('click', () => {
+  resetDishForm();
+  dishForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  dishForm.querySelector('input').focus();
+});
+
+resetFormBtn.addEventListener('click', resetDishForm);
+
+dishForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+
+  const formData = new FormData(dishForm);
+  const dish = Object.fromEntries(formData.entries());
+  dish.price = Number(dish.price);
+
+  if (!dish.name.trim()) {
+    dishNameInput.focus();
+    return;
+  }
+
+  if (state.editingDishId) {
+    const index = state.dishes.findIndex((item) => item.id === state.editingDishId);
+    if (index !== -1) {
+      state.dishes[index] = { ...state.dishes[index], ...dish };
+    }
+  } else {
+    state.dishes.unshift({ id: crypto.randomUUID(), ...dish });
+  }
+
+  resetDishForm();
+  renderDishes();
+});
+
+menuTable.addEventListener('click', (event) => {
+  const button = event.target.closest('button');
+  if (!button) return;
+
+  const { action, id } = button.dataset;
+  const dish = state.dishes.find((item) => item.id === id);
+
+  if (action === 'edit' && dish) {
+    state.editingDishId = id;
+    dishNameInput.value = dish.name;
+    dishCategoryInput.value = dish.category;
+    dishPriceInput.value = dish.price;
+    dishStatusInput.value = dish.status;
+    dishForm.querySelector('button[type="submit"]').textContent = 'Cập nhật món';
+    dishForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  if (action === 'delete' && dish) {
+    openConfirm(`Xóa món "${dish.name}"?`, () => {
+      state.dishes = state.dishes.filter((item) => item.id !== id);
+      renderDishes();
+    });
+  }
+});
+
+accountsTable.addEventListener('click', (event) => {
+  const button = event.target.closest('button');
+  if (!button) return;
+
+  const { action, id } = button.dataset;
+  const account = state.accounts.find((item) => item.id === id);
+
+  if (action === 'toggle' && account) {
+    const nextStatus = account.status === 'active' ? 'locked' : 'active';
+    account.status = nextStatus;
+    renderAccounts();
+  }
+
+  if (action === 'delete' && account) {
+    openConfirm(`Xóa tài khoản "${account.username}"?`, () => {
+      state.accounts = state.accounts.filter((item) => item.id !== id);
+      renderAccounts();
+    });
+  }
+});
+
+addAccountBtn.addEventListener('click', () => {
+  accountForm.reset();
+  accountDialog.showModal();
+  accountForm.accountUsername.focus();
+});
+
+accountDialog.addEventListener('close', () => {
+  if (accountDialog.returnValue !== 'confirm') return;
+
+  const formData = new FormData(accountForm);
+  const account = Object.fromEntries(formData.entries());
+  const username = account.username.trim();
+
+  if (!username) return;
+
+  if (state.accounts.some((item) => item.username === username)) {
+    alert('Tên đăng nhập đã tồn tại.');
+    return;
+  }
+
+  state.accounts.unshift({ id: crypto.randomUUID(), ...account });
+  renderAccounts();
+});
+
+function openConfirm(message, onConfirm) {
+  confirmMessage.textContent = message;
+  confirmDialog.showModal();
+  confirmDialog.onclose = () => {
+    if (confirmDialog.returnValue === 'confirm') {
+      onConfirm();
+    }
+  };
+}
+
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const setTheme = (dark) => {
+  document.documentElement.classList.toggle('dark', dark);
+  localStorage.setItem('ff-admin-theme', dark ? 'dark' : 'light');
+};
+
+setTheme(localStorage.getItem('ff-admin-theme') === 'dark' || prefersDark.matches);
+
+darkModeToggle.addEventListener('click', () => {
+  const isDark = document.documentElement.classList.toggle('dark');
+  localStorage.setItem('ff-admin-theme', isDark ? 'dark' : 'light');
+});
+
+prefersDark.addEventListener('change', (event) => {
+  const stored = localStorage.getItem('ff-admin-theme');
+  if (!stored) {
+    setTheme(event.matches);
+  }
+});
+
+renderOrders();
+renderDishes();
+renderAccounts();

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FoodFast Admin</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <img src="../public/logo.svg" alt="FoodFast" class="brand__logo" />
+          <span class="brand__name">FoodFast Admin</span>
+        </div>
+        <nav class="sidebar__nav">
+          <button class="nav__item active" data-target="orders">Quản lý đơn hàng</button>
+          <button class="nav__item" data-target="menu">Quản lý món ăn</button>
+          <button class="nav__item" data-target="accounts">Quản lý tài khoản</button>
+        </nav>
+        <div class="sidebar__footer">
+          <button class="logout-btn">Đăng xuất</button>
+        </div>
+      </aside>
+
+      <main class="content">
+        <header class="content__header">
+          <div class="header__title">
+            <h1>Trang quản trị FoodFast</h1>
+            <p>Theo dõi hoạt động đơn hàng, món ăn và tài khoản.</p>
+          </div>
+          <div class="header__actions">
+            <input
+              id="globalSearch"
+              type="search"
+              placeholder="Tìm kiếm nhanh..."
+              aria-label="Tìm kiếm"
+            />
+            <button id="darkModeToggle" class="icon-button" aria-label="Đổi giao diện">
+              🌗
+            </button>
+          </div>
+        </header>
+
+        <section id="orders" class="panel active">
+          <div class="panel__header">
+            <div>
+              <h2>Đơn hàng</h2>
+              <p>Theo dõi trạng thái và hình thức thanh toán của đơn hàng.</p>
+            </div>
+            <div class="panel__filters">
+              <select id="filterStatus">
+                <option value="all">Tất cả trạng thái</option>
+                <option value="delivering">Đang giao</option>
+                <option value="delivered">Đã giao</option>
+              </select>
+              <select id="filterPayment">
+                <option value="all">Tất cả thanh toán</option>
+                <option value="cash">Tiền mặt</option>
+                <option value="card">Thẻ</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="panel__body">
+            <table class="table" aria-label="Danh sách đơn hàng">
+              <thead>
+                <tr>
+                  <th>Mã đơn</th>
+                  <th>Khách hàng</th>
+                  <th>Trạng thái</th>
+                  <th>Thanh toán</th>
+                  <th>Giá trị</th>
+                  <th>Ngày tạo</th>
+                </tr>
+              </thead>
+              <tbody id="ordersTable"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="menu" class="panel">
+          <div class="panel__header">
+            <div>
+              <h2>Quản lý món ăn</h2>
+              <p>Thêm, chỉnh sửa hoặc xoá món trong thực đơn.</p>
+            </div>
+            <button id="addDishBtn" class="primary-btn">+ Thêm món</button>
+          </div>
+
+          <div class="panel__body">
+            <div class="grid">
+              <div class="card">
+                <h3>Thông tin món ăn</h3>
+                <form id="dishForm" novalidate>
+                  <div class="form-group">
+                    <label for="dishName">Tên món</label>
+                    <input id="dishName" name="name" required placeholder="Ví dụ: Bún chả" />
+                  </div>
+                  <div class="form-group">
+                    <label for="dishCategory">Danh mục</label>
+                    <input id="dishCategory" name="category" required placeholder="Món chính" />
+                  </div>
+                  <div class="form-group">
+                    <label for="dishPrice">Giá (VNĐ)</label>
+                    <input
+                      id="dishPrice"
+                      name="price"
+                      type="number"
+                      min="0"
+                      step="1000"
+                      required
+                      placeholder="75000"
+                    />
+                  </div>
+                  <div class="form-group">
+                    <label for="dishStatus">Trạng thái</label>
+                    <select id="dishStatus" name="status">
+                      <option value="available">Đang bán</option>
+                      <option value="out_of_stock">Hết hàng</option>
+                    </select>
+                  </div>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-btn">Lưu món</button>
+                    <button type="reset" class="ghost-btn" id="resetFormBtn">Hủy</button>
+                  </div>
+                </form>
+              </div>
+
+              <div class="card">
+                <div class="card__header">
+                  <h3>Danh sách món ăn</h3>
+                  <div class="chip" id="menuCount">0 món</div>
+                </div>
+                <table class="table" aria-label="Danh sách món ăn">
+                  <thead>
+                    <tr>
+                      <th>Tên</th>
+                      <th>Danh mục</th>
+                      <th>Giá</th>
+                      <th>Trạng thái</th>
+                      <th class="col-actions">Hành động</th>
+                    </tr>
+                  </thead>
+                  <tbody id="menuTable"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="accounts" class="panel">
+          <div class="panel__header">
+            <div>
+              <h2>Tài khoản</h2>
+              <p>Quản lý quyền truy cập và trạng thái tài khoản quản trị.</p>
+            </div>
+            <button id="addAccountBtn" class="primary-btn">+ Tạo tài khoản</button>
+          </div>
+
+          <div class="panel__body">
+            <div class="card">
+              <table class="table" aria-label="Danh sách tài khoản">
+                <thead>
+                  <tr>
+                    <th>Tên đăng nhập</th>
+                    <th>Họ tên</th>
+                    <th>Vai trò</th>
+                    <th>Trạng thái</th>
+                    <th class="col-actions">Hành động</th>
+                  </tr>
+                </thead>
+                <tbody id="accountsTable"></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <dialog id="accountDialog" class="modal">
+      <form method="dialog" id="accountForm">
+        <h3>Tạo tài khoản quản trị</h3>
+        <div class="form-group">
+          <label for="accountUsername">Tên đăng nhập</label>
+          <input id="accountUsername" name="username" required />
+        </div>
+        <div class="form-group">
+          <label for="accountFullName">Họ tên</label>
+          <input id="accountFullName" name="fullName" required />
+        </div>
+        <div class="form-group">
+          <label for="accountRole">Vai trò</label>
+          <select id="accountRole" name="role">
+            <option value="admin">Admin</option>
+            <option value="staff">Nhân viên</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="accountStatus">Trạng thái</label>
+          <select id="accountStatus" name="status">
+            <option value="active">Hoạt động</option>
+            <option value="locked">Đã khóa</option>
+          </select>
+        </div>
+        <div class="form-actions">
+          <button value="cancel" class="ghost-btn">Hủy</button>
+          <button value="confirm" class="primary-btn">Lưu</button>
+        </div>
+      </form>
+    </dialog>
+
+    <dialog id="confirmDialog" class="modal">
+      <form method="dialog">
+        <h3>Xác nhận thao tác</h3>
+        <p id="confirmMessage"></p>
+        <div class="form-actions">
+          <button value="cancel" class="ghost-btn">Hủy</button>
+          <button value="confirm" class="danger-btn">Xác nhận</button>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/admin/styles.css
+++ b/admin/styles.css
@@ -1,0 +1,447 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f7fb;
+  --bg-elevated: #ffffff;
+  --bg-sidebar: #101828;
+  --text-primary: #101828;
+  --text-secondary: #475467;
+  --text-inverse: #f8fafc;
+  --primary: #f97316;
+  --primary-dark: #ea580c;
+  --danger: #ef4444;
+  --border: #e4e7ec;
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --shadow-sm: 0 6px 18px rgba(15, 23, 42, 0.08);
+  --sidebar-width: 280px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+.dark {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --bg-elevated: #111c3d;
+  --bg-sidebar: #0b1222;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-inverse: #f1f5f9;
+  --primary: #fb923c;
+  --primary-dark: #f97316;
+  --border: #1e293b;
+  --shadow-sm: 0 6px 24px rgba(8, 47, 73, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text-primary);
+  font-family: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--bg-sidebar);
+  color: var(--text-inverse);
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.brand__logo {
+  width: 48px;
+  height: 48px;
+}
+
+.brand__name {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+.nav__item {
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  padding: 14px 18px;
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.nav__item:hover,
+.nav__item:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+}
+
+.nav__item.active {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateX(4px);
+}
+
+.sidebar__footer {
+  margin-top: auto;
+}
+
+.logout-btn {
+  width: 100%;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.content {
+  padding: 32px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.content__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.header__title h1 {
+  margin: 0 0 6px;
+  font-size: 1.8rem;
+}
+
+.header__title p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#globalSearch {
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: inherit;
+  min-width: 240px;
+}
+
+.icon-button {
+  border: none;
+  background: var(--bg-elevated);
+  border-radius: 50%;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.panel {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 28px;
+  display: none;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel.active {
+  display: flex;
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.panel__filters {
+  display: flex;
+  gap: 12px;
+}
+
+.panel__body {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.table thead {
+  background: rgba(15, 23, 42, 0.05);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.dark .table thead {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.table th,
+.table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.table tbody tr:hover {
+  background: rgba(249, 115, 22, 0.08);
+}
+
+.chip {
+  padding: 6px 12px;
+  background: rgba(249, 115, 22, 0.15);
+  color: var(--primary);
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.dark .chip {
+  background: rgba(251, 146, 60, 0.12);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 24px;
+}
+
+.card {
+  background: var(--bg);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  box-shadow: inset 0 0 0 1px var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-weight: 600;
+}
+
+.form-group input,
+.form-group select {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: inherit;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.primary-btn,
+.ghost-btn,
+.danger-btn {
+  border-radius: var(--radius-sm);
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.primary-btn {
+  background: var(--primary);
+  color: white;
+}
+
+.primary-btn:hover {
+  background: var(--primary-dark);
+}
+
+.ghost-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+}
+
+.danger-btn {
+  background: var(--danger);
+  color: white;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(15, 118, 110, 0.12);
+  color: #0f766e;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.status-pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.status-pill.delivering {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.status-pill.delivered {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.status-pill.cash {
+  background: rgba(249, 115, 22, 0.15);
+  color: var(--primary);
+}
+
+.status-pill.card {
+  background: rgba(14, 165, 233, 0.15);
+  color: #0284c7;
+}
+
+.col-actions {
+  width: 160px;
+}
+
+.table-actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.table-actions button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.table-actions button.delete {
+  color: var(--danger);
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 24px;
+  background: var(--bg-elevated);
+  color: inherit;
+  width: min(420px, 90vw);
+}
+
+.modal::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+@media (max-width: 1080px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 24px;
+  }
+
+  .sidebar__nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .nav__item {
+    padding: 10px 16px;
+  }
+
+  .content {
+    padding: 24px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .content__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #globalSearch {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone admin SPA shell with sections for đơn hàng, món ăn, and tài khoản quản trị
- style the admin layout with responsive cards, tables, and optional dark mode support
- implement client-side state handling for filtering, CRUD actions, and confirmation modals

## Testing
- not run (static admin assets)


------
https://chatgpt.com/codex/tasks/task_e_68f936b7b440832fbba0a23bac6fca91