### PR TITLE
Add Google Maps tracking and admin localization

### DIFF
--- a/admin/src/component/FoodEdit/FoodEdit.jsx
+++ b/admin/src/component/FoodEdit/FoodEdit.jsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import './FoodEdit.css'
+import { useAdminLanguage } from '../../context/LanguageContext'
 
 const FoodEdit = ({ food, onSave, onClose }) => {
     // Bản sao state để edit live
     const [editData, setEditData] = useState(food || {})
+    const { dictionary } = useAdminLanguage()
+    const t = dictionary.foodEdit
 
     useEffect(() => {
         setEditData(food)
@@ -36,9 +39,9 @@ const FoodEdit = ({ food, onSave, onClose }) => {
     return (
         <div className="popup-overlay">
             <form className="food-edit-popup" onSubmit={handleSubmit}>
-                <h3>Chỉnh sửa món: {food.name}</h3>
+                <h3>{t.title.replace('{{name}}', food.name)}</h3>
                 <label>
-                    Tên món
+                    {t.fields.name}
                     <input
                         name="name"
                         value={editData.name || ''}
@@ -47,7 +50,7 @@ const FoodEdit = ({ food, onSave, onClose }) => {
                     />
                 </label>
                 <label>
-                    Giá
+                    {t.fields.price}
                     <input
                         name="price"
                         value={editData.price || ''}
@@ -57,7 +60,7 @@ const FoodEdit = ({ food, onSave, onClose }) => {
                     />
                 </label>
                 <label>
-                    Danh mục
+                    {t.fields.category}
                     <input
                         name="category"
                         value={editData.category || ''}
@@ -66,7 +69,7 @@ const FoodEdit = ({ food, onSave, onClose }) => {
                     />
                 </label>
                 <label>
-                    Mô tả
+                    {t.fields.description}
                     <textarea
                         name="description"
                         value={editData.description || ''}
@@ -74,7 +77,7 @@ const FoodEdit = ({ food, onSave, onClose }) => {
                     />
                 </label>
                 <label>
-                    Thành phần (cách nhau bởi dấu phẩy)
+                    {t.fields.ingredients}
                     <input
                         name="ingredients"
                         value={
@@ -86,7 +89,7 @@ const FoodEdit = ({ food, onSave, onClose }) => {
                     />
                 </label>
                 <label>
-                    Địa chỉ
+                    {t.fields.address}
                     <input
                         name="address"
                         value={editData.address || ''}
@@ -94,8 +97,8 @@ const FoodEdit = ({ food, onSave, onClose }) => {
                     />
                 </label>
                 <div className="popup-btn-group">
-                    <button type="submit" className="save-btn">Lưu thay đổi</button>
-                    <button type="button" onClick={onClose} className="close-btn">Đóng</button>
+                    <button type="submit" className="save-btn">{t.actions.save}</button>
+                    <button type="button" onClick={onClose} className="close-btn">{t.actions.close}</button>
                 </div>
             </form>
         </div>

--- a/admin/src/component/Sidebar/Sidebar.jsx
+++ b/admin/src/component/Sidebar/Sidebar.jsx
@@ -2,25 +2,28 @@ import React from 'react'
 import './Sidebar.css'
 import { assests } from '../../assets/assest'
 import { NavLink } from 'react-router-dom'
+import { useAdminLanguage } from '../../context/LanguageContext'
 const Sidebar = () => {
+    const { dictionary } = useAdminLanguage()
+    const { sidebar } = dictionary
     return (
         <div className='sidebar'>
             <div className="sidebar-options">
                 <NavLink to='/add' className="sidebar-option">
                     <img src={assests.add_icon} alt="" />
-                    <p>Add New Item</p>
+                    <p>{sidebar.add}</p>
                 </NavLink>
                 <NavLink to='/list' className="sidebar-option">
                     <img src={assests.order_icon} alt="" />
-                    <p>List Items</p>
+                    <p>{sidebar.list}</p>
                 </NavLink>
                 <NavLink to='/orders' className="sidebar-option">
                     <img src={assests.order_icon} alt="" />
-                    <p>Orders</p>
+                    <p>{sidebar.orders}</p>
                 </NavLink>
                 <NavLink to='/tracking' className="sidebar-option">
                     <img src={assests.order_icon} alt="" />
-                    <p>Drone Tracking</p>
+                    <p>{sidebar.tracking}</p>
                 </NavLink>
             </div>
 

--- a/admin/src/component/navbar/Navbar.css
+++ b/admin/src/component/navbar/Navbar.css
@@ -8,3 +8,19 @@
 .navbar .logo {
     width: max(10%, 80px);
 }
+
+.navbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    color: #0f172a;
+}
+
+.navbar-actions select {
+    border: 1px solid #cbd5f5;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-size: 14px;
+    background: #fff;
+}

--- a/admin/src/component/navbar/Navbar.jsx
+++ b/admin/src/component/navbar/Navbar.jsx
@@ -1,11 +1,29 @@
 import React from 'react'
 import './Navbar.css'
 import { assests } from '../../assets/assest'
+import { useAdminLanguage } from '../../context/LanguageContext'
 
 const Navbar = () => {
+    const { dictionary, language, setLanguage, languageOptions } = useAdminLanguage()
+    const { navbar } = dictionary
+
     return (
         <div className='navbar'>
-            <img className='logo' src={assests.logo} alt="" />
+            <img className='logo' src={assests.logo} alt="FoodFast logo" />
+            <div className='navbar-actions'>
+                <label htmlFor='admin-language-select'>{navbar.languageLabel}</label>
+                <select
+                    id='admin-language-select'
+                    value={language}
+                    onChange={event => setLanguage(event.target.value)}
+                >
+                    {Object.entries(languageOptions).map(([code, label]) => (
+                        <option key={code} value={code}>
+                            {label}
+                        </option>
+                    ))}
+                </select>
+            </div>
         </div>
     )
 }

--- a/admin/src/context/LanguageContext.jsx
+++ b/admin/src/context/LanguageContext.jsx
@@ -1,0 +1,291 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+const translations = {
+  vi: {
+    languageName: 'Tiếng Việt',
+    common: {
+      currencyLocale: 'vi-VN',
+      currencySuffix: ' đ',
+      confirmDeleteProduct: 'Bạn muốn xoá sản phẩm này?',
+    },
+    navbar: {
+      languageLabel: 'Ngôn ngữ',
+    },
+    sidebar: {
+      add: 'Thêm món mới',
+      list: 'Danh sách món',
+      orders: 'Đơn hàng',
+      tracking: 'Theo dõi drone',
+    },
+    addPage: {
+      uploadLabel: 'Tải ảnh',
+      nameLabel: 'Tên món',
+      namePlaceholder: 'Nhập tên món',
+      descriptionLabel: 'Mô tả món ăn',
+      descriptionPlaceholder: 'Mô tả ngắn về món...',
+      categoryLabel: 'Danh mục',
+      categories: [
+        { value: 'Salad', label: 'Salad' },
+        { value: 'Rolls', label: 'Cuốn' },
+        { value: 'Deserts', label: 'Tráng miệng' },
+        { value: 'Sandwich', label: 'Sandwich' },
+        { value: 'Cake', label: 'Bánh ngọt' },
+        { value: 'Pure Veg', label: 'Chay' },
+        { value: 'Pasta', label: 'Mì Ý' },
+        { value: 'Noodles', label: 'Mì' },
+      ],
+      priceLabel: 'Giá món',
+      pricePlaceholder: '20.000',
+      submit: 'Thêm món',
+    },
+    listPage: {
+      title: 'Danh sách sản phẩm',
+      columns: {
+        image: 'Ảnh',
+        name: 'Tên',
+        description: 'Mô tả',
+        category: 'Danh mục',
+        price: 'Giá',
+        restaurant: 'Địa chỉ / Quán',
+        actions: '',
+      },
+      edit: 'Sửa',
+      delete: 'Xoá',
+      confirmDelete: 'Bạn muốn xoá sản phẩm này?',
+    },
+    ordersPage: {
+      title: 'Danh sách đơn hàng',
+      columns: {
+        customer: 'Khách hàng',
+        items: 'Sản phẩm',
+        address: 'Địa chỉ',
+        status: 'Trạng thái giao',
+        payment: 'Thanh toán',
+        total: 'Thành tiền',
+        actions: 'Điều chỉnh',
+      },
+      statuses: {
+        delivered: 'Đã giao',
+        pending: 'Chưa giao',
+      },
+      payment: {
+        paid: 'Đã thanh toán',
+        unpaid: 'Chưa thanh toán',
+      },
+      buttons: {
+        toggleStatus: 'Đổi trạng thái giao',
+        togglePayment: 'Đổi thanh toán',
+      },
+    },
+    trackingPage: {
+      headerTitle: 'Theo dõi drone giao hàng',
+      headerDescription:
+        'Giám sát trạng thái thực tế của các đơn hàng được giao bằng drone. Dữ liệu được cập nhật tự động vài giây một lần.',
+      selectorLabel: 'Chọn đơn hàng',
+      summaryLabels: {
+        customer: 'Khách hàng',
+        address: 'Địa chỉ giao',
+        status: 'Trạng thái',
+        payment: 'Thanh toán',
+        flightProgress: 'Tiến độ chuyến bay',
+        lastUpdate: 'Cập nhật cuối',
+        delivered: 'Đã giao',
+        inTransit: 'Đang giao',
+        paid: 'Đã thanh toán',
+        unpaid: 'Chưa thanh toán',
+        progressSuffix: '% hoàn thành',
+      },
+      legendPrefix: 'Drone #',
+      legendUpdated: 'Tọa độ hiện tại cập nhật lúc {{time}}',
+      timelineTitle: 'Lộ trình chuyến bay',
+      empty: 'Không tìm thấy thông tin đơn hàng.',
+    },
+    foodEdit: {
+      title: 'Chỉnh sửa món: {{name}}',
+      fields: {
+        name: 'Tên món',
+        price: 'Giá',
+        category: 'Danh mục',
+        description: 'Mô tả',
+        ingredients: 'Thành phần (cách nhau bởi dấu phẩy)',
+        address: 'Địa chỉ',
+      },
+      actions: {
+        save: 'Lưu thay đổi',
+        close: 'Đóng',
+      },
+    },
+  },
+  en: {
+    languageName: 'English',
+    common: {
+      currencyLocale: 'en-US',
+      currencySuffix: ' ₫',
+      confirmDeleteProduct: 'Do you want to delete this product?',
+    },
+    navbar: {
+      languageLabel: 'Language',
+    },
+    sidebar: {
+      add: 'Add new item',
+      list: 'List items',
+      orders: 'Orders',
+      tracking: 'Drone tracking',
+    },
+    addPage: {
+      uploadLabel: 'Upload image',
+      nameLabel: 'Product name',
+      namePlaceholder: 'Type name here',
+      descriptionLabel: 'Product description',
+      descriptionPlaceholder: 'Write a short description...',
+      categoryLabel: 'Product category',
+      categories: [
+        { value: 'Salad', label: 'Salad' },
+        { value: 'Rolls', label: 'Rolls' },
+        { value: 'Deserts', label: 'Desserts' },
+        { value: 'Sandwich', label: 'Sandwich' },
+        { value: 'Cake', label: 'Cake' },
+        { value: 'Pure Veg', label: 'Pure Veg' },
+        { value: 'Pasta', label: 'Pasta' },
+        { value: 'Noodles', label: 'Noodles' },
+      ],
+      priceLabel: 'Product price',
+      pricePlaceholder: '20,000',
+      submit: 'Add product',
+    },
+    listPage: {
+      title: 'Product list',
+      columns: {
+        image: 'Image',
+        name: 'Name',
+        description: 'Description',
+        category: 'Category',
+        price: 'Price',
+        restaurant: 'Restaurant / Address',
+        actions: '',
+      },
+      edit: 'Edit',
+      delete: 'Delete',
+      confirmDelete: 'Do you want to delete this product?',
+    },
+    ordersPage: {
+      title: 'Order list',
+      columns: {
+        customer: 'Customer',
+        items: 'Items',
+        address: 'Address',
+        status: 'Delivery status',
+        payment: 'Payment',
+        total: 'Total',
+        actions: 'Actions',
+      },
+      statuses: {
+        delivered: 'Delivered',
+        pending: 'Pending',
+      },
+      payment: {
+        paid: 'Paid',
+        unpaid: 'Unpaid',
+      },
+      buttons: {
+        toggleStatus: 'Toggle delivery status',
+        togglePayment: 'Toggle payment',
+      },
+    },
+    trackingPage: {
+      headerTitle: 'Monitor drone deliveries',
+      headerDescription:
+        'Follow live delivery progress for every drone order. Status updates refresh automatically every few seconds.',
+      selectorLabel: 'Select order',
+      summaryLabels: {
+        customer: 'Customer',
+        address: 'Delivery address',
+        status: 'Status',
+        payment: 'Payment',
+        flightProgress: 'Flight progress',
+        lastUpdate: 'Last update',
+        delivered: 'Delivered',
+        inTransit: 'In transit',
+        paid: 'Paid',
+        unpaid: 'Unpaid',
+        progressSuffix: '% complete',
+      },
+      legendPrefix: 'Drone #',
+      legendUpdated: 'Current co-ordinates updated at {{time}}',
+      timelineTitle: 'Flight route',
+      empty: 'Order information not available.',
+    },
+    foodEdit: {
+      title: 'Edit dish: {{name}}',
+      fields: {
+        name: 'Name',
+        price: 'Price',
+        category: 'Category',
+        description: 'Description',
+        ingredients: 'Ingredients (comma separated)',
+        address: 'Address',
+      },
+      actions: {
+        save: 'Save changes',
+        close: 'Close',
+      },
+    },
+  },
+}
+
+const languageOptions = Object.fromEntries(
+  Object.entries(translations).map(([code, value]) => [code, value.languageName])
+)
+
+const AdminLanguageContext = createContext({
+  language: 'vi',
+  setLanguage: () => {},
+  dictionary: translations.vi,
+  formatCurrency: value => value,
+  languageOptions,
+})
+
+const getInitialLanguage = () => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('foodfast-admin-language')
+    if (stored && translations[stored]) {
+      return stored
+    }
+  }
+  return 'vi'
+}
+
+export const AdminLanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState(getInitialLanguage)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('foodfast-admin-language', language)
+    }
+  }, [language])
+
+  const formatter = useMemo(
+    () => new Intl.NumberFormat(translations[language].common.currencyLocale),
+    [language]
+  )
+
+  const formatCurrency = useMemo(
+    () => value => `${formatter.format(value)}${translations[language].common.currencySuffix}`,
+    [formatter, language]
+  )
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      dictionary: translations[language],
+      formatCurrency,
+      languageOptions,
+    }),
+    [language, formatCurrency]
+  )
+
+  return <AdminLanguageContext.Provider value={value}>{children}</AdminLanguageContext.Provider>
+}
+
+export const useAdminLanguage = () => useContext(AdminLanguageContext)

--- a/admin/src/main.jsx
+++ b/admin/src/main.jsx
@@ -2,10 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import { BrowserRouter } from "react-router-dom"
+import { BrowserRouter } from 'react-router-dom'
+import { AdminLanguageProvider } from './context/LanguageContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <BrowserRouter>
-    <App />
+    <AdminLanguageProvider>
+      <App />
+    </AdminLanguageProvider>
   </BrowserRouter>
 )

--- a/admin/src/pages/Add/Add.jsx
+++ b/admin/src/pages/Add/Add.jsx
@@ -1,49 +1,49 @@
 import React, { useState } from 'react'
 import './Add.css'
 import { assests } from '../../assets/assest'
+import { useAdminLanguage } from '../../context/LanguageContext'
 
 const Add = () => {
 
     const [image, setIamge] = useState(false);
+    const { dictionary } = useAdminLanguage()
+    const t = dictionary.addPage
 
     return (
         <div className='add'>
             <form className='flex-col'>
                 <div className="add-img-upload flex-col">
-                    <p>Upload Image</p>
+                    <p>{t.uploadLabel}</p>
                     <label htmlFor="image">
                         <img src={assests.upload_area} alt="" />
                     </label>
                     <input type="file" id="image" hidden required />
                 </div>
                 <div className="add-product-name flex-col">
-                    <p>Product name</p>
-                    <input type="text" name='name' placeholder='Type here' />
+                    <p>{t.nameLabel}</p>
+                    <input type="text" name='name' placeholder={t.namePlaceholder} />
                 </div>
                 <div className="add-product-description flex-col">
-                    <p>Product description</p>
-                    <textarea name="description" rows="6" placeholder='Write content'></textarea>
+                    <p>{t.descriptionLabel}</p>
+                    <textarea name="description" rows="6" placeholder={t.descriptionPlaceholder}></textarea>
                 </div>
                 <div className="add-category-price">
                     <div className="add-category flex-col">
-                        <p>Product category</p>
+                        <p>{t.categoryLabel}</p>
                         <select name="category">
-                            <option value="Salad">Salad</option>
-                            <option value="Rolls">Rolls</option>
-                            <option value="Deserts">Deserts</option>
-                            <option value="Sandwich">Sandwich</option>
-                            <option value="Cake">Cake</option>
-                            <option value="Pure Veg">Pure Veg</option>
-                            <option value="Pasta">Pasta</option>
-                            <option value="Noodles">Noodles</option>
+                            {t.categories.map(option => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
                         </select>
                     </div>
                     <div className="add-price flex-col">
-                        <p>Product price</p>
-                        <input type="number" name='price' placeholder='20.000đ' />
+                        <p>{t.priceLabel}</p>
+                        <input type="number" name='price' placeholder={t.pricePlaceholder} />
                     </div>
                 </div>
-                <button type='submit' className='add-btn'>Add Product</button>
+                <button type='submit' className='add-btn'>{t.submit}</button>
             </form>
         </div>
     )

--- a/admin/src/pages/List/List.jsx
+++ b/admin/src/pages/List/List.jsx
@@ -2,14 +2,17 @@ import React, { useState } from 'react'
 import { food_list } from '../../assets/assest'
 import './List.css'
 import FoodEdit from '../../component/FoodEdit/FoodEdit' // Đường dẫn đúng đến FoodEdit.jsx
+import { useAdminLanguage } from '../../context/LanguageContext'
 
 const List = () => {
     const [products, setProducts] = useState(food_list)
     const [editingProduct, setEditingProduct] = useState(null)
+    const { dictionary, formatCurrency } = useAdminLanguage()
+    const t = dictionary.listPage
 
     // Xoá sản phẩm
     const handleDelete = (id) => {
-        if (window.confirm('Bạn muốn xoá sản phẩm này?')) {
+        if (window.confirm(t.confirmDelete)) {
             setProducts(products.filter(item => item._id !== id))
         }
     }
@@ -32,17 +35,17 @@ const List = () => {
 
     return (
         <div className="admin-products-list">
-            <h2>Danh sách sản phẩm</h2>
+            <h2>{t.title}</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Ảnh</th>
-                        <th>Tên</th>
-                        <th>Mô tả</th>
-                        <th>Danh mục</th>
-                        <th>Giá</th>
-                        <th>Địa chỉ / Quán</th>
-                        <th></th>
+                        <th>{t.columns.image}</th>
+                        <th>{t.columns.name}</th>
+                        <th>{t.columns.description}</th>
+                        <th>{t.columns.category}</th>
+                        <th>{t.columns.price}</th>
+                        <th>{t.columns.restaurant}</th>
+                        <th>{t.columns.actions}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -54,14 +57,14 @@ const List = () => {
                             <td>{item.name}</td>
                             <td>{item.description}</td>
                             <td>{item.category}</td>
-                            <td>{item.price.toLocaleString()} đ</td>
+                            <td>{formatCurrency(item.price)}</td>
                             <td>
                                 {item.restaurant?.name}<br />
                                 <span style={{ fontSize: 12, color: '#888' }}>{item.restaurant?.address}</span>
                             </td>
                             <td>
-                                <button className="edit-btn" onClick={() => handleEdit(item)}>Sửa</button>
-                                <button className="delete-btn" onClick={() => handleDelete(item._id)}>Xoá</button>
+                                <button className="edit-btn" onClick={() => handleEdit(item)}>{t.edit}</button>
+                                <button className="delete-btn" onClick={() => handleDelete(item._id)}>{t.delete}</button>
                             </td>
                         </tr>
                     ))}

--- a/admin/src/pages/Orders/Orders.jsx
+++ b/admin/src/pages/Orders/Orders.jsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react'
 import { order_list } from '../../assets/assest'
 import './Orders.css'
+import { useAdminLanguage } from '../../context/LanguageContext'
 
 const Orders = () => {
     const [orders, setOrders] = useState(order_list)
+    const { dictionary, formatCurrency } = useAdminLanguage()
+    const t = dictionary.ordersPage
 
     // Toggle trạng thái giao hàng (Cho từng order)
     const handleToggleStatus = (id) => {
@@ -35,17 +38,17 @@ const Orders = () => {
 
     return (
         <div className="admin-orders-list">
-            <h2>Danh sách đơn hàng</h2>
+            <h2>{t.title}</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>Khách hàng</th>
-                        <th>Sản phẩm</th>
-                        <th>Địa chỉ</th>
-                        <th>Trạng thái giao</th>
-                        <th>Thanh toán</th>
-                        <th>Thành tiền</th>
-                        <th>Điều chỉnh</th>
+                        <th>{t.columns.customer}</th>
+                        <th>{t.columns.items}</th>
+                        <th>{t.columns.address}</th>
+                        <th>{t.columns.status}</th>
+                        <th>{t.columns.payment}</th>
+                        <th>{t.columns.total}</th>
+                        <th>{t.columns.actions}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -58,28 +61,29 @@ const Orders = () => {
                                         <span style={{ fontWeight: 500 }}>{it.name}</span>
                                         {" "}x{it.quantity || 1}
                                         <span style={{ color: '#888', marginLeft: 2, fontSize: 15 }}>
-                                            ({(Number(it.price) * Number(it.quantity || 1)).toLocaleString()}đ)
+                                            ({formatCurrency(Number(it.price) * Number(it.quantity || 1))})
                                         </span>
                                     </div>
                                 )}
                             </td>
                             <td>{order.address}</td>
                             <td>
-                                <span className={order.status === 'delivered' ? 'badge badge-delivered' : 'badge badge-pending'}>
-                                    {order.status === 'delivered' ? 'Đã giao' : 'Chưa giao'}
+                                <span className={order.status === 'delivered' ? 'badge badge-delivered' : 'badge badge-pending'}
+>
+                                    {order.status === 'delivered' ? t.statuses.delivered : t.statuses.pending}
                                 </span>
                             </td>
                             <td>
                                 <span className={order.paid ? 'badge badge-paid' : 'badge badge-unpaid'}>
-                                    {order.paid ? 'Đã thanh toán' : 'Chưa thanh toán'}
+                                    {order.paid ? t.payment.paid : t.payment.unpaid}
                                 </span>
                             </td>
                             <td>
-                                {getOrderTotal(order).toLocaleString()} đ
+                                {formatCurrency(getOrderTotal(order))}
                             </td>
                             <td>
-                                <button onClick={() => handleToggleStatus(order.id)}>Đổi trạng thái giao</button>
-                                <button onClick={() => handleTogglePaid(order.id)}>Đổi thanh toán</button>
+                                <button onClick={() => handleToggleStatus(order.id)}>{t.buttons.toggleStatus}</button>
+                                <button onClick={() => handleTogglePaid(order.id)}>{t.buttons.togglePayment}</button>
                             </td>
                         </tr>
                     )}

--- a/admin/src/pages/Tracking/Tracking.jsx
+++ b/admin/src/pages/Tracking/Tracking.jsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import './Tracking.css'
 import { order_list } from '../../assets/assest'
+import { useAdminLanguage } from '../../context/LanguageContext'
 
 const getInitialOrderId = () => order_list[0]?.id ?? ''
 
 const Tracking = () => {
     const [selectedOrderId, setSelectedOrderId] = useState(getInitialOrderId)
+    const { dictionary } = useAdminLanguage()
+    const t = dictionary.trackingPage
+
     const selectedOrder = useMemo(
         () => order_list.find(order => order.id === selectedOrderId),
         [selectedOrderId]
@@ -62,18 +66,27 @@ const Tracking = () => {
 
     const completion = route.length > 1 ? (progress / (route.length - 1)) * 100 : 0
 
+    const statusLabel = selectedOrder?.status === 'delivered'
+        ? t.summaryLabels.delivered
+        : t.summaryLabels.inTransit
+
+    const paymentLabel = selectedOrder?.paid
+        ? t.summaryLabels.paid
+        : t.summaryLabels.unpaid
+
+    const legendText = t.legendUpdated.replace('{{time}}', lastUpdated.toLocaleTimeString())
+
     return (
         <div className='tracking-page'>
             <header className='tracking-header'>
                 <div>
-                    <h2>Theo dõi drone giao hàng</h2>
+                    <h2>{t.headerTitle}</h2>
                     <p>
-                        Giám sát trạng thái thực tế của các đơn hàng được giao bằng drone.
-                        Dữ liệu được cập nhật tự động vài giây một lần.
+                        {t.headerDescription}
                     </p>
                 </div>
                 <div className='tracking-selector'>
-                    <label htmlFor='order-select'>Chọn đơn hàng</label>
+                    <label htmlFor='order-select'>{t.selectorLabel}</label>
                     <select
                         id='order-select'
                         value={selectedOrderId}
@@ -92,34 +105,34 @@ const Tracking = () => {
                 <div className='tracking-content'>
                     <section className='tracking-summary'>
                         <div className='summary-card'>
-                            <span className='summary-label'>Khách hàng</span>
+                            <span className='summary-label'>{t.summaryLabels.customer}</span>
                             <strong>{selectedOrder.customer}</strong>
                         </div>
                         <div className='summary-card'>
-                            <span className='summary-label'>Địa chỉ giao</span>
+                            <span className='summary-label'>{t.summaryLabels.address}</span>
                             <strong>{selectedOrder.address}</strong>
                         </div>
                         <div className='summary-card'>
-                            <span className='summary-label'>Trạng thái</span>
+                            <span className='summary-label'>{t.summaryLabels.status}</span>
                             <strong className={selectedOrder.status === 'delivered' ? 'badge-success' : 'badge-pending'}>
-                                {selectedOrder.status === 'delivered' ? 'Đã giao' : 'Đang giao'}
+                                {statusLabel}
                             </strong>
                         </div>
                         <div className='summary-card'>
-                            <span className='summary-label'>Thanh toán</span>
+                            <span className='summary-label'>{t.summaryLabels.payment}</span>
                             <strong className={selectedOrder.paid ? 'badge-success' : 'badge-pending'}>
-                                {selectedOrder.paid ? 'Đã thanh toán' : 'Chưa thanh toán'}
+                                {paymentLabel}
                             </strong>
                         </div>
                         <div className='summary-card'>
-                            <span className='summary-label'>Tiến độ chuyến bay</span>
+                            <span className='summary-label'>{t.summaryLabels.flightProgress}</span>
                             <div className='progress'>
                                 <div className='progress-bar' style={{ width: `${completion}%` }} />
                             </div>
-                            <small>{Math.round(completion)}% hoàn thành</small>
+                            <small>{Math.round(completion)} {t.summaryLabels.progressSuffix}</small>
                         </div>
                         <div className='summary-card'>
-                            <span className='summary-label'>Cập nhật cuối</span>
+                            <span className='summary-label'>{t.summaryLabels.lastUpdate}</span>
                             <strong>{lastUpdated.toLocaleTimeString()}</strong>
                         </div>
                     </section>
@@ -157,11 +170,11 @@ const Tracking = () => {
                             </div>
                             <div className='map-legend'>
                                 <strong>Drone #{selectedOrder.id.toUpperCase()}</strong>
-                                <span>Tọa độ hiện tại cập nhật lúc {lastUpdated.toLocaleTimeString()}</span>
+                                <span>{legendText}</span>
                             </div>
                         </div>
                         <aside className='tracking-timeline'>
-                            <h3>Lộ trình chuyến bay</h3>
+                            <h3>{t.timelineTitle}</h3>
                             <ul>
                                 {route.map((point, index) => {
                                     const isCompleted = index < currentIndex || progress >= route.length - 1
@@ -184,7 +197,7 @@ const Tracking = () => {
                     </section>
                 </div>
             ) : (
-                <p>Không tìm thấy thông tin đơn hàng.</p>
+                <p>{t.empty}</p>
             )}
         </div>
     )

--- a/frontend/src/Context/LanguageContext.jsx
+++ b/frontend/src/Context/LanguageContext.jsx
@@ -22,7 +22,9 @@ const translationData = {
       searchAria: 'Tìm kiếm',
       cartAria: 'Xem giỏ hàng',
       cartAlt: 'Giỏ hàng',
-      loginCta: 'Đăng Nhập',
+      loginCta: 'Đăng nhập',
+      signInCta: 'Đăng nhập',
+      signOutCta: 'Đăng xuất',
       navAria: 'Điều hướng chính',
     },
     header: {
@@ -120,6 +122,14 @@ const translationData = {
         prefix: 'Drone #',
         updated: 'Tọa độ cập nhật lúc {{time}}',
       },
+      loginRequiredTitle: 'Cần đăng nhập',
+      loginRequiredDescription:
+        'Vui lòng đăng nhập để theo dõi đơn hàng của bạn. Hệ thống chỉ hiển thị các chuyến bay thuộc tài khoản hiện tại.',
+      noOrdersTitle: 'Chưa có đơn để theo dõi',
+      noOrdersDescription:
+        'Chúng tôi chưa tìm thấy đơn hàng nào thuộc tài khoản của bạn. Hãy đặt món và quay lại trang này sau nhé!',
+      mapUnavailable:
+        'Không thể tải bản đồ Google Maps. Vui lòng kiểm tra khóa API VITE_GOOGLE_MAPS_API_KEY.',
       summaryLabels: {
         customer: 'Khách hàng',
         address: 'Địa chỉ giao',
@@ -139,6 +149,7 @@ const translationData = {
           code: 'FF-1024',
           customer: 'Nguyễn Văn A',
           address: '212 Lý Chính Thắng, Quận 3',
+          customerEmail: 'vu191@gmail.com',
           status: 'inTransit',
           paid: true,
           route: [
@@ -148,6 +159,7 @@ const translationData = {
               title: 'Nhận món tại nhà hàng',
               description: 'Drone đã nhận đơn tại KFC Nguyễn Trãi và đang kiểm tra cảm biến.',
               position: { x: 10, y: 70 },
+              coords: { lat: 10.762622, lng: 106.660172 },
             },
             {
               id: 'takeoff',
@@ -155,6 +167,7 @@ const translationData = {
               title: 'Drone cất cánh',
               description: 'Thiết bị bay rời bãi đáp và tăng độ cao lên 60m.',
               position: { x: 25, y: 55 },
+              coords: { lat: 10.764752, lng: 106.670419 },
             },
             {
               id: 'enroute',
@@ -162,6 +175,7 @@ const translationData = {
               title: 'Đang trên đường giao',
               description: 'Drone đang di chuyển qua Quận 1 với vận tốc ổn định 40 km/h.',
               position: { x: 50, y: 45 },
+              coords: { lat: 10.770421, lng: 106.68394 },
             },
             {
               id: 'arriving',
@@ -169,6 +183,7 @@ const translationData = {
               title: 'Chuẩn bị hạ cánh',
               description: 'Drone giảm độ cao và gửi thông báo cho khách chuẩn bị nhận đơn.',
               position: { x: 75, y: 40 },
+              coords: { lat: 10.776866, lng: 106.688123 },
             },
             {
               id: 'delivered',
@@ -176,6 +191,7 @@ const translationData = {
               title: 'Hoàn tất giao hàng',
               description: 'Đơn hàng dự kiến giao cho khách trong vòng 2 phút nữa.',
               position: { x: 88, y: 65 },
+              coords: { lat: 10.780497, lng: 106.700195 },
             },
           ],
         },
@@ -184,6 +200,7 @@ const translationData = {
           code: 'FF-1072',
           customer: 'Trần Thị B',
           address: '45 Trần Hưng Đạo, Quận 1',
+          customerEmail: 'tranthi.b@example.com',
           status: 'delivered',
           paid: false,
           route: [
@@ -193,6 +210,7 @@ const translationData = {
               title: 'Nhận món tại nhà hàng',
               description: 'Drone tiếp nhận pizza tại Pizza 4P và niêm phong khoang hàng.',
               position: { x: 8, y: 75 },
+              coords: { lat: 10.771853, lng: 106.698055 },
             },
             {
               id: 'takeoff',
@@ -200,6 +218,7 @@ const translationData = {
               title: 'Drone cất cánh',
               description: 'Drone rời điểm xuất phát với mức pin 92%.',
               position: { x: 22, y: 60 },
+              coords: { lat: 10.772922, lng: 106.706451 },
             },
             {
               id: 'enroute',
@@ -207,6 +226,7 @@ const translationData = {
               title: 'Đang trên đường giao',
               description: 'Thiết bị bay băng qua đại lộ Nguyễn Huệ, tránh vùng gió mạnh.',
               position: { x: 48, y: 47 },
+              coords: { lat: 10.775458, lng: 106.712894 },
             },
             {
               id: 'arriving',
@@ -214,6 +234,7 @@ const translationData = {
               title: 'Chuẩn bị hạ cánh',
               description: 'Drone yêu cầu khách hàng xác nhận vị trí hạ cánh an toàn.',
               position: { x: 70, y: 45 },
+              coords: { lat: 10.779611, lng: 106.708012 },
             },
             {
               id: 'delivered',
@@ -221,6 +242,7 @@ const translationData = {
               title: 'Hoàn tất giao hàng',
               description: 'Đơn hàng được bàn giao thành công và đang quay về bãi sạc.',
               position: { x: 90, y: 60 },
+              coords: { lat: 10.782537, lng: 106.700721 },
             },
           ],
         },
@@ -263,6 +285,8 @@ const translationData = {
       cartAria: 'View cart',
       cartAlt: 'Cart',
       loginCta: 'Sign in',
+      signInCta: 'Sign in',
+      signOutCta: 'Sign out',
       navAria: 'Main navigation',
     },
     header: {
@@ -360,6 +384,14 @@ const translationData = {
         prefix: 'Drone #',
         updated: 'Location updated at {{time}}',
       },
+      loginRequiredTitle: 'Sign-in required',
+      loginRequiredDescription:
+        'Log in to follow along with your delivery. Only orders belonging to the active account are displayed.',
+      noOrdersTitle: 'No deliveries to track yet',
+      noOrdersDescription:
+        'We could not find any orders linked to your account. Place an order and come back to watch the drone fly!',
+      mapUnavailable:
+        'Unable to load Google Maps. Make sure the VITE_GOOGLE_MAPS_API_KEY environment variable is configured.',
       summaryLabels: {
         customer: 'Customer',
         address: 'Delivery address',
@@ -379,6 +411,7 @@ const translationData = {
           code: 'FF-1024',
           customer: 'Nguyễn Văn A',
           address: '212 Lý Chính Thắng, District 3',
+          customerEmail: 'vu191@gmail.com',
           status: 'inTransit',
           paid: true,
           route: [
@@ -388,6 +421,7 @@ const translationData = {
               title: 'Picked up at restaurant',
               description: 'Drone collected the meal at KFC Nguyễn Trãi and is running safety checks.',
               position: { x: 10, y: 70 },
+              coords: { lat: 10.762622, lng: 106.660172 },
             },
             {
               id: 'takeoff',
@@ -395,6 +429,7 @@ const translationData = {
               title: 'Drone take-off',
               description: 'The aircraft leaves the launch pad and climbs to 60m altitude.',
               position: { x: 25, y: 55 },
+              coords: { lat: 10.764752, lng: 106.670419 },
             },
             {
               id: 'enroute',
@@ -402,6 +437,7 @@ const translationData = {
               title: 'En route to customer',
               description: 'Flying across District 1 at a steady 40 km/h with clear skies.',
               position: { x: 50, y: 45 },
+              coords: { lat: 10.770421, lng: 106.68394 },
             },
             {
               id: 'arriving',
@@ -409,6 +445,7 @@ const translationData = {
               title: 'Preparing to land',
               description: 'Drone descends and notifies the customer to get ready for delivery.',
               position: { x: 75, y: 40 },
+              coords: { lat: 10.776866, lng: 106.688123 },
             },
             {
               id: 'delivered',
@@ -416,6 +453,7 @@ const translationData = {
               title: 'Delivery almost complete',
               description: 'Package will be handed over to the customer within 2 minutes.',
               position: { x: 88, y: 65 },
+              coords: { lat: 10.780497, lng: 106.700195 },
             },
           ],
         },
@@ -424,6 +462,7 @@ const translationData = {
           code: 'FF-1072',
           customer: 'Trần Thị B',
           address: '45 Trần Hưng Đạo, District 1',
+          customerEmail: 'tranthi.b@example.com',
           status: 'delivered',
           paid: false,
           route: [
@@ -433,6 +472,7 @@ const translationData = {
               title: 'Picked up at restaurant',
               description: 'Drone secured the pizza at Pizza 4P and sealed the cargo bay.',
               position: { x: 8, y: 75 },
+              coords: { lat: 10.771853, lng: 106.698055 },
             },
             {
               id: 'takeoff',
@@ -440,6 +480,7 @@ const translationData = {
               title: 'Drone take-off',
               description: 'Departure confirmed with a healthy 92% battery level.',
               position: { x: 22, y: 60 },
+              coords: { lat: 10.772922, lng: 106.706451 },
             },
             {
               id: 'enroute',
@@ -447,6 +488,7 @@ const translationData = {
               title: 'En route to customer',
               description: 'Crossing Nguyễn Huệ boulevard while navigating strong winds.',
               position: { x: 48, y: 47 },
+              coords: { lat: 10.775458, lng: 106.712894 },
             },
             {
               id: 'arriving',
@@ -454,6 +496,7 @@ const translationData = {
               title: 'Preparing to land',
               description: 'Drone requested the customer to confirm a safe landing spot.',
               position: { x: 70, y: 45 },
+              coords: { lat: 10.779611, lng: 106.708012 },
             },
             {
               id: 'delivered',
@@ -461,6 +504,7 @@ const translationData = {
               title: 'Delivery completed',
               description: 'Order delivered successfully and now heading back to the charging hub.',
               position: { x: 90, y: 60 },
+              coords: { lat: 10.782537, lng: 106.700721 },
             },
           ],
         },

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -30,6 +30,7 @@ const Navbar = () => {
   const handleLogout = () => {
     localStorage.removeItem('user')
     setUser(null)
+    window.dispatchEvent(new CustomEvent('foodfast-auth-change'))
     window.location.reload()
   }
 
@@ -38,6 +39,7 @@ const Navbar = () => {
     const loggedUser = localStorage.getItem('user')
     if (loggedUser) {
       setUser(JSON.parse(loggedUser))
+      window.dispatchEvent(new CustomEvent('foodfast-auth-change'))
     }
     setOpenLogin(false)
   }
@@ -82,7 +84,7 @@ const Navbar = () => {
               type='button'
               onClick={() => setOpenLogin(true)}
             >
-              Sign In
+              {navText.signInCta}
             </button>
           ) : (
             <button
@@ -91,7 +93,7 @@ const Navbar = () => {
               type='button'
               onClick={handleLogout}
             >
-              Sign Out
+              {navText.signOutCta}
             </button>
           )}
         </div>

--- a/frontend/src/pages/ModalLogin/ModalLogin.jsx
+++ b/frontend/src/pages/ModalLogin/ModalLogin.jsx
@@ -48,6 +48,7 @@ export default function ModalLogin({ open, onClose, onLoginSuccess }) {
         const matched = Array.isArray(users) && users.find((u) => u.email?.toLowerCase() === email.trim().toLowerCase() && u.password === password)
         if (matched) {
           localStorage.setItem('user', JSON.stringify(matched))
+          window.dispatchEvent(new CustomEvent('foodfast-auth-change'))
           setSuccess('Đăng nhập thành công')
           setTimeout(() => {
             resetForm()

--- a/frontend/src/pages/OrderTracking/GoogleDroneMap.jsx
+++ b/frontend/src/pages/OrderTracking/GoogleDroneMap.jsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+const SCRIPT_ID = 'google-maps-sdk'
+
+const loadGoogleMaps = apiKey => {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('window is undefined'))
+  }
+
+  if (window.google && window.google.maps) {
+    return Promise.resolve(window.google)
+  }
+
+  const existingScript = document.getElementById(SCRIPT_ID)
+  if (existingScript) {
+    return new Promise((resolve, reject) => {
+      existingScript.addEventListener('load', () => resolve(window.google))
+      existingScript.addEventListener('error', () => reject(new Error('Google Maps failed to load')))
+    })
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.id = SCRIPT_ID
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}`
+    script.async = true
+    script.defer = true
+    script.onload = () => resolve(window.google)
+    script.onerror = () => reject(new Error('Google Maps failed to load'))
+    document.head.appendChild(script)
+  })
+}
+
+const createDroneIcon = google => {
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+  <svg width="56" height="56" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#38bdf8" />
+        <stop offset="100%" stop-color="#6366f1" />
+      </linearGradient>
+    </defs>
+    <circle cx="28" cy="28" r="24" fill="url(#grad)" opacity="0.92" />
+    <path d="M28 14l4 6h-8l4-6zm0 28l-4-6h8l-4 6zm14-14l-6 4v-8l6 4zm-28 0l6-4v8l-6-4z" fill="#f8fafc"/>
+  </svg>`
+
+  return {
+    url: `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`,
+    scaledSize: new google.maps.Size(56, 56),
+    anchor: new google.maps.Point(28, 28),
+  }
+}
+
+const GoogleDroneMap = ({ route, droneCoordinate, orderCode, unavailableMessage }) => {
+  const containerRef = useRef(null)
+  const mapRef = useRef(null)
+  const polylineRef = useRef(null)
+  const droneMarkerRef = useRef(null)
+  const checkpointsRef = useRef([])
+  const [error, setError] = useState('')
+  const [isReady, setIsReady] = useState(false)
+
+  const coordinates = useMemo(
+    () =>
+      Array.isArray(route)
+        ? route
+            .map(point => point?.coords)
+            .filter(Boolean)
+        : [],
+    [route]
+  )
+
+  useEffect(() => {
+    if (!containerRef.current) return undefined
+
+    if (!coordinates.length) {
+      setError(unavailableMessage)
+      return undefined
+    }
+
+    const apiKey = import.meta.env?.VITE_GOOGLE_MAPS_API_KEY
+    if (!apiKey) {
+      setError(unavailableMessage)
+      return undefined
+    }
+
+    let cancelled = false
+
+    const initialiseMap = async () => {
+      try {
+        const google = await loadGoogleMaps(apiKey)
+        if (cancelled) return
+
+        if (!containerRef.current) return
+
+        // Cleanup previous map artefacts
+        if (polylineRef.current) {
+          polylineRef.current.setMap(null)
+          polylineRef.current = null
+        }
+        checkpointsRef.current.forEach(marker => marker.setMap(null))
+        checkpointsRef.current = []
+        if (droneMarkerRef.current) {
+          droneMarkerRef.current.setMap(null)
+          droneMarkerRef.current = null
+        }
+        mapRef.current = new google.maps.Map(containerRef.current, {
+          center: coordinates[0],
+          zoom: 14,
+          disableDefaultUI: true,
+          styles: [
+            {
+              featureType: 'poi',
+              stylers: [{ visibility: 'off' }],
+            },
+          ],
+        })
+
+        polylineRef.current = new google.maps.Polyline({
+          map: mapRef.current,
+          path: coordinates,
+          strokeColor: '#2563eb',
+          strokeOpacity: 0.9,
+          strokeWeight: 4,
+        })
+
+        const bounds = new google.maps.LatLngBounds()
+        coordinates.forEach(coord => bounds.extend(coord))
+        mapRef.current.fitBounds(bounds, 48)
+
+        const startMarker = new google.maps.Marker({
+          map: mapRef.current,
+          position: coordinates[0],
+          label: { text: 'A', color: '#0f172a', fontWeight: 'bold' },
+        })
+        const endMarker = new google.maps.Marker({
+          map: mapRef.current,
+          position: coordinates[coordinates.length - 1],
+          label: { text: 'B', color: '#0f172a', fontWeight: 'bold' },
+        })
+        checkpointsRef.current = [startMarker, endMarker]
+        setError('')
+        setIsReady(true)
+      } catch (err) {
+        console.error(err)
+        setError(unavailableMessage)
+        setIsReady(false)
+      }
+    }
+
+    initialiseMap()
+
+    return () => {
+      cancelled = true
+    }
+  }, [coordinates, unavailableMessage])
+
+  useEffect(() => {
+    if (!isReady || !mapRef.current || !droneCoordinate) return
+    const google = window.google
+    if (!google?.maps) return
+
+    if (!droneMarkerRef.current) {
+      droneMarkerRef.current = new google.maps.Marker({
+        map: mapRef.current,
+        position: droneCoordinate,
+        title: orderCode ? `Drone ${orderCode}` : 'Drone position',
+        icon: createDroneIcon(google),
+        zIndex: 10,
+      })
+    } else {
+      droneMarkerRef.current.setPosition(droneCoordinate)
+    }
+
+    mapRef.current.panTo(droneCoordinate)
+  }, [droneCoordinate, isReady, orderCode])
+
+  useEffect(() => () => {
+    if (polylineRef.current) {
+      polylineRef.current.setMap(null)
+      polylineRef.current = null
+    }
+    checkpointsRef.current.forEach(marker => marker.setMap(null))
+    checkpointsRef.current = []
+    if (droneMarkerRef.current) {
+      droneMarkerRef.current.setMap(null)
+      droneMarkerRef.current = null
+    }
+    mapRef.current = null
+  }, [])
+
+  return (
+    <div className='google-map-wrapper'>
+      <div ref={containerRef} className='google-map-canvas' role='presentation' />
+      {error && <div className='map-error'>{error}</div>}
+    </div>
+  )
+}
+
+export default GoogleDroneMap

--- a/frontend/src/pages/OrderTracking/OrderTracking.css
+++ b/frontend/src/pages/OrderTracking/OrderTracking.css
@@ -61,6 +61,11 @@
   box-shadow: 0 12px 35px rgba(15, 23, 42, 0.12);
 }
 
+.hero-selector select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .order-tracking-content {
   display: flex;
   flex-direction: column;
@@ -144,82 +149,44 @@
 
 .tracking-map {
   position: relative;
-  background: linear-gradient(160deg, rgba(14, 165, 233, 0.12), rgba(99, 102, 241, 0.1));
-  border-radius: 28px;
-  padding: 28px;
-  min-height: 380px;
-  overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.25), 0 25px 45px rgba(15, 23, 42, 0.2);
-}
-
-.map-overlay {
-  position: absolute;
-  inset: 24px;
-}
-
-.map-line {
-  position: absolute;
-  background: rgba(148, 163, 184, 0.3);
-}
-
-.map-line.horizontal {
-  left: 0;
-  right: 0;
-  height: 1px;
-}
-
-.map-line.vertical {
-  top: 0;
-  bottom: 0;
-  width: 1px;
-}
-
-.map-point {
-  position: absolute;
-  transform: translate(-50%, -50%);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 6px;
+  gap: 16px;
 }
 
-.map-point-dot {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: #2563eb;
-  box-shadow: 0 0 0 8px rgba(37, 99, 235, 0.2);
+.google-map-wrapper {
+  position: relative;
+  min-height: 380px;
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.25), 0 25px 45px rgba(15, 23, 42, 0.2);
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.12), rgba(99, 102, 241, 0.1));
 }
 
-.map-point-label {
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
-  padding: 6px 10px;
-  border-radius: 12px;
-  font-size: 13px;
-  white-space: nowrap;
+.google-map-canvas {
+  width: 100%;
+  height: 100%;
 }
 
-.map-drone {
+.map-error {
   position: absolute;
-  transform: translate(-50%, -50%);
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: #0f172a;
-  color: #f8fafc;
+  inset: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
-  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.25);
-  transition: left 1.8s ease, top 1.8s ease;
+  text-align: center;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.86);
+  color: #f8fafc;
+  font-weight: 500;
+  line-height: 1.5;
 }
 
 .map-legend {
   position: absolute;
-  left: 24px;
-  bottom: 24px;
+  left: 28px;
+  bottom: 28px;
   background: rgba(15, 23, 42, 0.9);
   color: #e2e8f0;
   padding: 14px 18px;
@@ -316,12 +283,49 @@
   color: #475569;
 }
 
+.order-tracking-empty {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 36px 32px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 680px;
+}
+
+.order-tracking-empty h2 {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 32px);
+}
+
+.order-tracking-empty p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.order-tracking-link {
+  align-self: flex-start;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #38bdf8, #6366f1);
+  color: #f8fafc;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.2);
+}
+
+.order-tracking-link:hover {
+  opacity: 0.92;
+}
+
 @media (max-width: 1024px) {
   .tracking-grid {
     grid-template-columns: 1fr;
   }
 
-  .tracking-map {
+  .google-map-wrapper {
     min-height: 320px;
   }
 }

--- a/frontend/src/pages/OrderTracking/OrderTracking.jsx
+++ b/frontend/src/pages/OrderTracking/OrderTracking.jsx
@@ -1,24 +1,77 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import './OrderTracking.css'
 import { useLanguage } from '../../Context/LanguageContext'
+import GoogleDroneMap from './GoogleDroneMap'
 
 const OrderTracking = () => {
   const { dictionary } = useLanguage()
   const { trackingPage } = dictionary
 
-  const [selectedOrderId, setSelectedOrderId] = useState(
-    trackingPage.orders[0]?.id ?? ''
-  )
+  const [user, setUser] = useState(() => {
+    if (typeof window === 'undefined') return null
+    const stored = window.localStorage.getItem('user')
+    if (!stored) return null
+    try {
+      return JSON.parse(stored)
+    } catch (error) {
+      console.error(error)
+      return null
+    }
+  })
 
   useEffect(() => {
-    if (!trackingPage.orders.some(order => order.id === selectedOrderId)) {
-      setSelectedOrderId(trackingPage.orders[0]?.id ?? '')
+    if (typeof window === 'undefined') return undefined
+
+    const syncUser = () => {
+      try {
+        const stored = window.localStorage.getItem('user')
+        if (!stored) {
+          setUser(null)
+          return
+        }
+        setUser(JSON.parse(stored))
+      } catch (error) {
+        console.error(error)
+        setUser(null)
+      }
     }
-  }, [trackingPage.orders, selectedOrderId])
+
+    window.addEventListener('storage', syncUser)
+    window.addEventListener('foodfast-auth-change', syncUser)
+
+    return () => {
+      window.removeEventListener('storage', syncUser)
+      window.removeEventListener('foodfast-auth-change', syncUser)
+    }
+  }, [])
+
+  const availableOrders = useMemo(() => {
+    if (!user?.email) return []
+    return trackingPage.orders.filter(order =>
+      order.customerEmail?.toLowerCase() === user.email.toLowerCase()
+    )
+  }, [trackingPage.orders, user?.email])
+
+  const [selectedOrderId, setSelectedOrderId] = useState('')
+
+  useEffect(() => {
+    if (!user) {
+      setSelectedOrderId('')
+      return
+    }
+    if (!availableOrders.length) {
+      setSelectedOrderId('')
+      return
+    }
+    if (!availableOrders.some(order => order.id === selectedOrderId)) {
+      setSelectedOrderId(availableOrders[0].id)
+    }
+  }, [availableOrders, selectedOrderId, user])
 
   const selectedOrder = useMemo(
-    () => trackingPage.orders.find(order => order.id === selectedOrderId),
-    [trackingPage.orders, selectedOrderId]
+    () => availableOrders.find(order => order.id === selectedOrderId),
+    [availableOrders, selectedOrderId]
   )
 
   const route = selectedOrder?.route ?? []
@@ -31,16 +84,15 @@ const OrderTracking = () => {
   }, [selectedOrderId])
 
   useEffect(() => {
-    const routeLength = route.length
-    if (routeLength < 2) return undefined
+    if (route.length < 2) return undefined
 
     const timer = setInterval(() => {
       setProgress(prev => {
         const next = prev + 0.015
-        if (next >= routeLength - 1) {
+        if (next >= route.length - 1) {
           clearInterval(timer)
           setLastUpdated(new Date())
-          return routeLength - 1
+          return route.length - 1
         }
         setLastUpdated(new Date())
         return next
@@ -57,41 +109,38 @@ const OrderTracking = () => {
   const currentPoint = route[currentIndex] ?? route[0]
   const nextPoint = route[nextIndex] ?? route[route.length - 1]
 
-  const dronePosition = () => {
-    if (!currentPoint) {
-      return { left: '10%', top: '70%' }
+  const droneCoordinate = useMemo(() => {
+    if (!currentPoint?.coords) return null
+    if (!nextPoint?.coords) {
+      return { ...currentPoint.coords }
     }
-    if (!nextPoint) {
-      return {
-        left: `${currentPoint.position.x}%`,
-        top: `${currentPoint.position.y}%`,
-      }
-    }
-    const left =
-      currentPoint.position.x +
-      (nextPoint.position.x - currentPoint.position.x) * segmentProgress
-    const top =
-      currentPoint.position.y +
-      (nextPoint.position.y - currentPoint.position.y) * segmentProgress
-
     return {
-      left: `${left}%`,
-      top: `${top}%`,
+      lat:
+        currentPoint.coords.lat +
+        (nextPoint.coords.lat - currentPoint.coords.lat) * segmentProgress,
+      lng:
+        currentPoint.coords.lng +
+        (nextPoint.coords.lng - currentPoint.coords.lng) * segmentProgress,
     }
-  }
+  }, [currentPoint, nextPoint, segmentProgress])
 
   const completion = route.length > 1 ? (progress / (route.length - 1)) * 100 : 0
 
   const summaryLabels = trackingPage.summaryLabels
 
-  const statusLabel =
-    selectedOrder?.status === 'delivered'
-      ? summaryLabels.delivered
-      : summaryLabels.inTransit
+  const statusLabel = selectedOrder?.status === 'delivered'
+    ? summaryLabels.delivered
+    : summaryLabels.inTransit
 
-  const paymentLabel = selectedOrder?.paid
-    ? summaryLabels.paid
-    : summaryLabels.unpaid
+  const paymentLabel = selectedOrder?.paid ? summaryLabels.paid : summaryLabels.unpaid
+
+  const selectorDisabled = !user || availableOrders.length === 0
+  const selectValue = selectorDisabled ? '' : selectedOrderId
+
+  const legendText = trackingPage.legend.updated.replace(
+    '{{time}}',
+    lastUpdated.toLocaleTimeString()
+  )
 
   return (
     <main className='order-tracking-page'>
@@ -105,19 +154,42 @@ const OrderTracking = () => {
           <label htmlFor='tracking-order-select'>{trackingPage.selectorLabel}</label>
           <select
             id='tracking-order-select'
-            value={selectedOrderId}
+            value={selectValue}
             onChange={event => setSelectedOrderId(event.target.value)}
+            disabled={selectorDisabled}
           >
-            {trackingPage.orders.map(order => (
-              <option key={order.id} value={order.id}>
-                {order.code} — {order.customer}
+            {selectorDisabled ? (
+              <option value=''>
+                {!user ? trackingPage.loginRequiredTitle : trackingPage.noOrdersTitle}
               </option>
-            ))}
+            ) : (
+              availableOrders.map(order => (
+                <option key={order.id} value={order.id}>
+                  {order.code} — {order.customer}
+                </option>
+              ))
+            )}
           </select>
         </div>
       </section>
 
-      {selectedOrder ? (
+      {!user ? (
+        <section className='order-tracking-empty'>
+          <h2>{trackingPage.loginRequiredTitle}</h2>
+          <p>{trackingPage.loginRequiredDescription}</p>
+          <Link to='/' className='order-tracking-link'>
+            {dictionary.navbar.signInCta}
+          </Link>
+        </section>
+      ) : !availableOrders.length ? (
+        <section className='order-tracking-empty'>
+          <h2>{trackingPage.noOrdersTitle}</h2>
+          <p>{trackingPage.noOrdersDescription}</p>
+          <Link to='/menu' className='order-tracking-link'>
+            {dictionary.cart.emptyCta}
+          </Link>
+        </section>
+      ) : selectedOrder ? (
         <section className='order-tracking-content'>
           <div className='tracking-summary'>
             <article className='summary-card'>
@@ -163,49 +235,20 @@ const OrderTracking = () => {
 
           <div className='tracking-grid'>
             <div className='tracking-map'>
-              <div className='map-overlay'>
-                {[...Array(4)].map((_, index) => (
-                  <span
-                    key={`h-${index}`}
-                    className='map-line horizontal'
-                    style={{ top: `${(index + 1) * 20}%` }}
-                  />
-                ))}
-                {[...Array(4)].map((_, index) => (
-                  <span
-                    key={`v-${index}`}
-                    className='map-line vertical'
-                    style={{ left: `${(index + 1) * 20}%` }}
-                  />
-                ))}
-              </div>
-              {route.map(point => (
-                <div
-                  key={point.id}
-                  className='map-point'
-                  style={{ left: `${point.position.x}%`, top: `${point.position.y}%` }}
-                >
-                  <span className='map-point-dot' />
-                  <span className='map-point-label'>{point.title}</span>
-                </div>
-              ))}
-              <div className='map-drone' style={dronePosition()}>
-                <span role='img' aria-label='Drone icon'>🚁</span>
-              </div>
+              <GoogleDroneMap
+                route={route}
+                droneCoordinate={droneCoordinate}
+                orderCode={selectedOrder.code}
+                unavailableMessage={trackingPage.mapUnavailable}
+              />
               <div className='map-legend'>
                 <strong>
                   {trackingPage.legend.prefix}
                   {selectedOrder.code}
                 </strong>
-                <span>
-                  {trackingPage.legend.updated.replace(
-                    '{{time}}',
-                    lastUpdated.toLocaleTimeString(),
-                  )}
-                </span>
+                <span>{legendText}</span>
               </div>
             </div>
-
             <aside className='tracking-timeline'>
               <h2>{trackingPage.timelineTitle}</h2>
               <ul>


### PR DESCRIPTION
## Summary
- integrate a Google Maps experience on the customer tracking page, restrict viewing to logged-in users, and expand translations for the new messaging and flight data
- update the frontend navbar and login flow to broadcast auth changes and surface translated button labels
- introduce an admin-side language context with selector, translate page copy, and format order totals with locale-aware currency strings

## Testing
- npm run build (frontend)
- npm run build (admin)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cefd30608323a639d11c7dd7703e)