### PR TITLE
Connect checkout orders to tracking and fix order totals

### DIFF
--- a/admin/src/pages/Orders/Orders.jsx
+++ b/admin/src/pages/Orders/Orders.jsx
@@ -1,40 +1,157 @@
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { order_list } from '../../assets/assest'
 import './Orders.css'
 import { useAdminLanguage } from '../../context/LanguageContext'
 
+const ORDERS_STORAGE_KEY = 'foodfast-orders'
+
+const readStoredOrders = () => {
+    if (typeof window === 'undefined') return []
+    try {
+        const data = window.localStorage.getItem(ORDERS_STORAGE_KEY)
+        if (!data) return []
+        const parsed = JSON.parse(data)
+        return Array.isArray(parsed) ? parsed : []
+    } catch (error) {
+        console.error(error)
+        return []
+    }
+}
+
+const digitsOnly = (value) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.max(0, value)
+    }
+    if (typeof value === 'string') {
+        const numeric = value.replace(/[^0-9]/g, '')
+        return numeric ? Number(numeric) : 0
+    }
+    return 0
+}
+
+const normaliseItem = (item) => ({
+    name: item?.name ?? 'Sản phẩm',
+    quantity: Math.max(1, digitsOnly(item?.quantity)),
+    price: digitsOnly(item?.price),
+})
+
+let fallbackIdCounter = 0
+const nextFallbackId = () => {
+    fallbackIdCounter += 1
+    return `order-${fallbackIdCounter}`
+}
+
+const transformOrder = (order) => {
+    const items = Array.isArray(order?.items) ? order.items.map(normaliseItem) : []
+    const status = order?.adminStatus ?? order?.status
+    return {
+        id: order?.id ?? nextFallbackId(),
+        customer: order?.customer ?? 'Khách hàng',
+        address: order?.address ?? '',
+        status: status === 'delivered' ? 'delivered' : 'pending',
+        trackingStatus: order?.trackingStatus,
+        paid: Boolean(order?.paid),
+        deliveryFee: digitsOnly(order?.deliveryFee),
+        total: digitsOnly(order?.total),
+        items,
+        createdAt: order?.createdAt ?? null,
+    }
+}
+
+const mergeOrders = (baseOrders, dynamicOrders) => {
+    const unique = new Map()
+    baseOrders.forEach(order => unique.set(order.id, order))
+    dynamicOrders.forEach(order => unique.set(order.id, order))
+    return Array.from(unique.values())
+}
+
+const calculateOrderTotal = (order) => {
+    const itemsTotal = order.items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+    const deliveryFee = order.deliveryFee || 0
+    const storedTotal = order.total || 0
+    return storedTotal || (itemsTotal + deliveryFee)
+}
+
 const Orders = () => {
-    const [orders, setOrders] = useState(order_list)
     const { dictionary, formatCurrency } = useAdminLanguage()
     const t = dictionary.ordersPage
 
-    // Toggle trạng thái giao hàng (Cho từng order)
+    const staticOrders = useMemo(() => order_list.map(transformOrder), [])
+    const loadOrders = () => {
+        const storedOrders = readStoredOrders().map(transformOrder)
+        return mergeOrders(staticOrders, storedOrders)
+    }
+
+    const [orders, setOrders] = useState(loadOrders)
+
+    useEffect(() => {
+        const syncOrders = () => setOrders(loadOrders())
+        syncOrders()
+        window.addEventListener('storage', syncOrders)
+        window.addEventListener('foodfast-orders-update', syncOrders)
+        return () => {
+            window.removeEventListener('storage', syncOrders)
+            window.removeEventListener('foodfast-orders-update', syncOrders)
+        }
+    }, [staticOrders])
+
+    const updateStoredOrder = (id, updater) => {
+        const existing = readStoredOrders()
+        const index = existing.findIndex(order => order.id === id)
+        if (index === -1) return
+        const current = existing[index]
+        const changes = typeof updater === 'function' ? updater(current) : updater
+        existing[index] = { ...current, ...changes }
+        window.localStorage.setItem(ORDERS_STORAGE_KEY, JSON.stringify(existing))
+        window.dispatchEvent(new CustomEvent('foodfast-orders-update'))
+    }
+
     const handleToggleStatus = (id) => {
-        setOrders(
-            orders.map(order =>
-                order.id === id
-                    ? { ...order, status: order.status === 'pending' ? 'delivered' : 'pending' }
-                    : order
-            )
-        )
+        setOrders(prev => {
+            let nextStatus = null
+            let nextTrackingStatus = null
+            const updated = prev.map(order => {
+                if (order.id !== id) return order
+                const isDelivered = order.status === 'delivered'
+                nextStatus = isDelivered ? 'pending' : 'delivered'
+                nextTrackingStatus = order.trackingStatus
+                    ? (order.trackingStatus === 'delivered' ? 'inTransit' : 'delivered')
+                    : undefined
+                return {
+                    ...order,
+                    status: nextStatus,
+                    trackingStatus: nextTrackingStatus ?? order.trackingStatus,
+                }
+            })
+
+            if (nextStatus) {
+                updateStoredOrder(id, current => ({
+                    adminStatus: nextStatus,
+                    status: nextStatus,
+                    trackingStatus: nextTrackingStatus ?? current.trackingStatus,
+                }))
+            }
+
+            return updated
+        })
     }
 
-    // Toggle thanh toán (cho từng order)
     const handleTogglePaid = (id) => {
-        setOrders(
-            orders.map(order =>
-                order.id === id
-                    ? { ...order, paid: !order.paid }
-                    : order
-            )
-        )
-    }
+        setOrders(prev => {
+            let nextPaid = null
+            const updated = prev.map(order => {
+                if (order.id !== id) return order
+                nextPaid = !order.paid
+                return { ...order, paid: nextPaid }
+            })
 
-    // Tính tổng thành tiền đúng (quantity x price)
-    const getOrderTotal = (order) =>
-        order.items.reduce((sum, it) =>
-            sum + (Number(it.price) * Number(it.quantity || 1)), 0
-        )
+            if (nextPaid !== null) {
+                updateStoredOrder(id, { paid: nextPaid })
+            }
+
+            return updated
+        })
+    }
 
     return (
         <div className="admin-orders-list">
@@ -52,24 +169,23 @@ const Orders = () => {
                     </tr>
                 </thead>
                 <tbody>
-                    {orders.map(order =>
+                    {orders.map(order => (
                         <tr key={order.id}>
                             <td>{order.customer}</td>
                             <td style={{ minWidth: '160px' }}>
-                                {order.items.map((it, idx) =>
+                                {order.items.map((it, idx) => (
                                     <div key={idx} style={{ marginBottom: 5 }}>
                                         <span style={{ fontWeight: 500 }}>{it.name}</span>
-                                        {" "}x{it.quantity || 1}
+                                        {" "}x{it.quantity}
                                         <span style={{ color: '#888', marginLeft: 2, fontSize: 15 }}>
-                                            ({formatCurrency(Number(it.price) * Number(it.quantity || 1))})
+                                            ({formatCurrency(it.price * it.quantity)})
                                         </span>
                                     </div>
-                                )}
+                                ))}
                             </td>
                             <td>{order.address}</td>
                             <td>
-                                <span className={order.status === 'delivered' ? 'badge badge-delivered' : 'badge badge-pending'}
->
+                                <span className={order.status === 'delivered' ? 'badge badge-delivered' : 'badge badge-pending'}>
                                     {order.status === 'delivered' ? t.statuses.delivered : t.statuses.pending}
                                 </span>
                             </td>
@@ -79,14 +195,14 @@ const Orders = () => {
                                 </span>
                             </td>
                             <td>
-                                {formatCurrency(getOrderTotal(order))}
+                                {formatCurrency(calculateOrderTotal(order))}
                             </td>
                             <td>
                                 <button onClick={() => handleToggleStatus(order.id)}>{t.buttons.toggleStatus}</button>
                                 <button onClick={() => handleTogglePaid(order.id)}>{t.buttons.togglePayment}</button>
                             </td>
                         </tr>
-                    )}
+                    ))}
                 </tbody>
             </table>
         </div>

--- a/frontend/src/pages/OrderTracking/GoogleDroneMap.jsx
+++ b/frontend/src/pages/OrderTracking/GoogleDroneMap.jsx
@@ -341,10 +341,33 @@ const GoogleDroneMap = ({
     mapRef.current = null
   }, [])
 
+  const showFallback = Boolean(error)
+
   return (
     <div className='google-map-wrapper'>
-      <div ref={containerRef} className='google-map-canvas' role='presentation' />
-      {error && <div className='map-error'>{error}</div>}
+      <div
+        ref={containerRef}
+        className={`google-map-canvas${showFallback ? ' is-hidden' : ''}`}
+        role='presentation'
+        aria-hidden={showFallback}
+      />
+      {showFallback && (
+        <div className='map-fallback' role='status'>
+          <div className='map-fallback-icon' aria-hidden='true'>🚁</div>
+          <p>{error}</p>
+          {route?.length ? (
+            <ol className='map-fallback-steps'>
+              {route.map(point => (
+                <li key={point.id}>
+                  <strong>{point.title}</strong>
+                  {point.eta && <span>{point.eta}</span>}
+                  <p>{point.description}</p>
+                </li>
+              ))}
+            </ol>
+          ) : null}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/OrderTracking/OrderTracking.css
+++ b/frontend/src/pages/OrderTracking/OrderTracking.css
@@ -168,18 +168,72 @@
   height: 100%;
 }
 
-.map-error {
+.google-map-canvas.is-hidden {
+  display: none;
+}
+
+.map-fallback {
   position: absolute;
-  inset: 16px;
+  inset: 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 16px;
   text-align: center;
-  padding: 16px;
-  border-radius: 20px;
-  background: rgba(15, 23, 42, 0.86);
+  padding: 32px 24px;
   color: #f8fafc;
+  background: radial-gradient(circle at top, rgba(14, 165, 233, 0.3), rgba(30, 64, 175, 0.85));
+}
+
+.map-fallback-icon {
+  font-size: 44px;
+  filter: drop-shadow(0 12px 18px rgba(15, 23, 42, 0.45));
+}
+
+.map-fallback p {
+  margin: 0;
+  max-width: 340px;
+  font-size: 16px;
+  line-height: 1.6;
   font-weight: 500;
+}
+
+.map-fallback-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(400px, 100%);
+  text-align: left;
+}
+
+.map-fallback-steps li {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 14px;
+  padding: 12px 16px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 12px;
+}
+
+.map-fallback-steps li strong {
+  font-size: 15px;
+  color: #facc15;
+}
+
+.map-fallback-steps li span {
+  font-size: 13px;
+  color: rgba(241, 245, 249, 0.78);
+}
+
+.map-fallback-steps li p {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.9);
   line-height: 1.5;
 }
 

--- a/frontend/src/pages/OrderTracking/OrderTracking.jsx
+++ b/frontend/src/pages/OrderTracking/OrderTracking.jsx
@@ -4,9 +4,46 @@ import './OrderTracking.css'
 import { useLanguage } from '../../Context/LanguageContext'
 import GoogleDroneMap from './GoogleDroneMap'
 
+const ORDERS_STORAGE_KEY = 'foodfast-orders'
+
+const readStoredOrders = () => {
+  if (typeof window === 'undefined') return []
+  try {
+    const data = window.localStorage.getItem(ORDERS_STORAGE_KEY)
+    if (!data) return []
+    const parsed = JSON.parse(data)
+    return Array.isArray(parsed) ? parsed : []
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
+const toUniqueOrders = orders => {
+  const map = new Map()
+  orders.forEach(order => {
+    if (order?.id) {
+      map.set(order.id, order)
+    }
+  })
+  return Array.from(map.values())
+}
+
+const byRecency = (a, b) => {
+  const parseTimestamp = value => {
+    if (!value) return Number.NEGATIVE_INFINITY
+    const timestamp = Date.parse(value)
+    return Number.isFinite(timestamp) ? timestamp : Number.NEGATIVE_INFINITY
+  }
+
+  return parseTimestamp(b?.createdAt) - parseTimestamp(a?.createdAt)
+}
+
 const OrderTracking = () => {
   const { dictionary } = useLanguage()
   const { trackingPage } = dictionary
+
+  const [storedOrders, setStoredOrders] = useState(() => readStoredOrders())
 
   const [user, setUser] = useState(() => {
     if (typeof window === 'undefined') return null
@@ -46,12 +83,34 @@ const OrderTracking = () => {
     }
   }, [])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const syncOrders = () => {
+      setStoredOrders(readStoredOrders())
+    }
+
+    syncOrders()
+    window.addEventListener('storage', syncOrders)
+    window.addEventListener('foodfast-orders-update', syncOrders)
+
+    return () => {
+      window.removeEventListener('storage', syncOrders)
+      window.removeEventListener('foodfast-orders-update', syncOrders)
+    }
+  }, [])
+
+  const allOrders = useMemo(() => {
+    const merged = toUniqueOrders([...trackingPage.orders, ...storedOrders])
+    return merged.sort(byRecency)
+  }, [storedOrders, trackingPage.orders])
+
   const availableOrders = useMemo(() => {
     if (!user?.email) return []
-    return trackingPage.orders.filter(order =>
+    return allOrders.filter(order =>
       order.customerEmail?.toLowerCase() === user.email.toLowerCase()
     )
-  }, [trackingPage.orders, user?.email])
+  }, [allOrders, user?.email])
 
   const [selectedOrderId, setSelectedOrderId] = useState('')
 
@@ -128,7 +187,8 @@ const OrderTracking = () => {
 
   const summaryLabels = trackingPage.summaryLabels
 
-  const statusLabel = selectedOrder?.status === 'delivered'
+  const orderStatus = selectedOrder?.trackingStatus ?? selectedOrder?.status
+  const statusLabel = orderStatus === 'delivered'
     ? summaryLabels.delivered
     : summaryLabels.inTransit
 

--- a/frontend/src/pages/PlaceOrder/PlaceOrder.jsx
+++ b/frontend/src/pages/PlaceOrder/PlaceOrder.jsx
@@ -1,11 +1,75 @@
-import React, { useContext, useState, useEffect } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import './PlaceOrder.css'
 import { StoreContext } from '../../Context/StoreContext'
 import { useNavigate } from 'react-router-dom'
 
+const ORDERS_STORAGE_KEY = 'foodfast-orders'
+
+const generateOrderCode = (timestamp) => {
+    const randomSegment = Math.floor(100 + (timestamp % 900))
+    const suffix = String(timestamp).slice(-3)
+    return `FF-${randomSegment}${suffix}`
+}
+
+const generateRoute = (createdAt, address) => {
+    const baseLat = 10.772673
+    const baseLng = 106.660987
+    const seed = createdAt.getTime() / 1000
+    const pseudoRandom = (factor) => {
+        const x = Math.sin(seed * factor) * 10000
+        return x - Math.floor(x)
+    }
+
+    const latDelta = 0.015 + pseudoRandom(1.3) * 0.008
+    const lngDelta = 0.02 + pseudoRandom(0.7) * 0.01
+
+    const checkpoints = [
+        { offset: 0, id: 'pickup', title: 'Nhận món tại bếp trung tâm', description: 'Đơn hàng đã được xác nhận và đang đóng gói.' },
+        { offset: 2, id: 'takeoff', title: 'Drone cất cánh', description: 'Drone rời bãi đáp và tăng độ cao an toàn.' },
+        { offset: 6, id: 'enroute', title: 'Đang giao hàng', description: 'Drone di chuyển đến khu vực giao với tốc độ ổn định.' },
+        { offset: 9, id: 'arriving', title: 'Chuẩn bị hạ cánh', description: 'Drone giảm độ cao và thông báo cho khách chuẩn bị nhận hàng.' },
+        { offset: 12, id: 'delivered', title: 'Hoàn tất giao hàng', description: `Đơn hàng sẽ được giao tại ${address}.` },
+    ]
+
+    const etaFormatter = new Intl.DateTimeFormat('vi-VN', {
+        hour: '2-digit',
+        minute: '2-digit',
+    })
+
+    return checkpoints.map((checkpoint, index) => {
+        const progression = index / (checkpoints.length - 1 || 1)
+        const coords = {
+            lat: baseLat + latDelta * progression,
+            lng: baseLng + lngDelta * progression,
+        }
+
+        const eta = new Date(createdAt.getTime() + checkpoint.offset * 60 * 1000)
+
+        return {
+            id: checkpoint.id,
+            eta: etaFormatter.format(eta),
+            title: checkpoint.title,
+            description: checkpoint.description,
+            coords,
+        }
+    })
+}
+
+const readStoredOrders = () => {
+    if (typeof window === 'undefined') return []
+    try {
+        const data = window.localStorage.getItem(ORDERS_STORAGE_KEY)
+        if (!data) return []
+        const parsed = JSON.parse(data)
+        return Array.isArray(parsed) ? parsed : []
+    } catch (error) {
+        console.error(error)
+        return []
+    }
+}
 
 const PlaceOrder = () => {
-    const { cartTotal } = useContext(StoreContext)
+    const { cartItems, cartTotal, food_list, setCartItems } = useContext(StoreContext)
     const deliveryFee = cartTotal > 0 && cartTotal < 100000 ? 15000 : 0
     const grandTotal = cartTotal + deliveryFee
 
@@ -13,7 +77,6 @@ const PlaceOrder = () => {
     const [orderPlaced, setOrderPlaced] = useState(false)
 
     const navigate = useNavigate()
-
 
     const [form, setForm] = useState({
         fullName: '',
@@ -23,6 +86,21 @@ const PlaceOrder = () => {
         state: '',
         voucher: ''
     })
+
+    const selectedItems = useMemo(() => {
+        return Object.entries(cartItems).reduce((items, [itemId, quantity]) => {
+            if (!quantity) return items
+            const product = food_list.find(food => food._id === itemId)
+            if (!product) return items
+            items.push({
+                id: product._id,
+                name: product.name,
+                price: product.price,
+                quantity,
+            })
+            return items
+        }, [])
+    }, [cartItems, food_list])
 
     // Khi component mount, lấy dữ liệu localStorage nếu có
     useEffect(() => {
@@ -39,23 +117,70 @@ const PlaceOrder = () => {
         ...prev, [e.target.name]: e.target.value
     }))
 
+    const formatCurrency = value => value.toLocaleString('vi-VN', {
+        style: 'currency', currency: 'VND', maximumFractionDigits: 0
+    })
+
     const handleSubmit = e => {
         e.preventDefault()
         if (!form.fullName.trim() || !form.phone.trim() || !form.street.trim() || !form.city.trim() || !form.state.trim()) {
             alert('Bạn cần điền đầy đủ thông tin bắt buộc!')
             return
         }
+
+        if (!selectedItems.length) {
+            alert('Giỏ hàng của bạn đang trống')
+            return
+        }
+
+        const loggedUser = window.localStorage.getItem('user')
+        if (!loggedUser) {
+            alert('Vui lòng đăng nhập trước khi đặt hàng để theo dõi chuyến bay của bạn.')
+            return
+        }
+
+        const user = JSON.parse(loggedUser)
+        const createdAt = new Date()
+        const code = generateOrderCode(createdAt.getTime())
+        const fullAddress = `${form.street}, ${form.state}, ${form.city}`
+
+        const newOrder = {
+            id: `local-${createdAt.getTime()}`,
+            code,
+            customer: form.fullName.trim(),
+            customerPhone: form.phone.trim(),
+            customerEmail: user?.email ?? '',
+            address: fullAddress,
+            items: selectedItems.map(item => ({
+                ...item,
+                price: Number(item.price),
+                quantity: Number(item.quantity),
+            })),
+            subtotal: cartTotal,
+            deliveryFee,
+            total: grandTotal,
+            status: 'pending',
+            trackingStatus: 'inTransit',
+            paid: paymentMethod !== 'cod',
+            paymentMethod,
+            route: generateRoute(createdAt, fullAddress),
+            createdAt: createdAt.toISOString(),
+        }
+
+        const existingOrders = readStoredOrders()
+        const updatedOrders = [...existingOrders, newOrder]
+        window.localStorage.setItem(ORDERS_STORAGE_KEY, JSON.stringify(updatedOrders))
+        window.dispatchEvent(new CustomEvent('foodfast-orders-update'))
+
         setOrderPlaced(true)
+        window.localStorage.removeItem('checkoutInfo')
+        setCartItems({})
+
         setTimeout(() => {
             setOrderPlaced(false)
-            navigate('/')
-        }, 1000)
+            navigate('/tracking')
+        }, 1200)
     }
-
-
-    const formatCurrency = value => value.toLocaleString('vi-VN', {
-        style: 'currency', currency: 'VND', maximumFractionDigits: 0
-    })
 
     return (
         <form className='place-order' onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- persist placed orders locally with generated drone routes so tracking can show new deliveries
- guard checkout submission, clear the cart, and provide a fallback drone map UI when Google Maps is unavailable
- hydrate the admin order table from stored orders, normalise currency math, and keep status/payment toggles in sync

## Testing
- npm run build (frontend)
- npm run build (admin)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910de4542c48323bce0fc2c03646ef6)