### PR TITLE
Add super admin dashboard page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,11 @@
+.app--super-admin {
+  width: 100%;
+  margin: 0;
+  min-height: 100vh;
+  background-color: #eef1f8;
+}
+
+.app--super-admin .super-admin {
+  width: 100%;
+  margin: 0;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Routes } from 'react-router-dom'
+import { Route, Routes, useLocation } from 'react-router-dom'
 import Navbar from './components/Navbar/Navbar'
 import Cart from './pages/Cart/Cart'
 import Contact from './pages/Contact/Contact'
@@ -9,11 +9,16 @@ import PlaceOrder from './pages/PlaceOrder/PlaceOrder'
 import Footer from './components/Footer/Footer'
 import FoodDetail from './components/FoodDetail/FoodDetail'
 import OrderTracking from './pages/OrderTracking/OrderTracking'
+import SuperAdmin from './pages/SuperAdmin/SuperAdmin'
+import './App.css'
 
 const App = () => {
+  const location = useLocation()
+  const isSuperAdminRoute = location.pathname.startsWith('/super-admin')
+
   return (
-    <div className="app">
-      <Navbar />
+    <div className={`app${isSuperAdminRoute ? ' app--super-admin' : ''}`}>
+      {!isSuperAdminRoute && <Navbar />}
       <Routes>
         <Route path='/' element={<Home />} />
         <Route path='/menu' element={<Menu />} />
@@ -22,8 +27,9 @@ const App = () => {
         <Route path='/order' element={<PlaceOrder />} />
         <Route path='/tracking' element={<OrderTracking />} />
         <Route path="/food/:id" element={<FoodDetail />} />
+        <Route path='/super-admin' element={<SuperAdmin />} />
       </Routes>
-      <Footer />
+      {!isSuperAdminRoute && <Footer />}
     </div>
   )
 }

--- a/frontend/src/pages/SuperAdmin/SuperAdmin.css
+++ b/frontend/src/pages/SuperAdmin/SuperAdmin.css
@@ -1,0 +1,352 @@
+.super-admin {
+  min-height: 100vh;
+  padding: 2.5rem 3rem 3rem;
+  background: linear-gradient(180deg, #f5f7fb 0%, #eef1f8 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.super-admin__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.super-admin__header h1 {
+  font-size: 2rem;
+  color: #1b2559;
+  margin-bottom: 0.5rem;
+}
+
+.super-admin__header p {
+  color: #6b7280;
+}
+
+.super-admin__actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.super-admin__actions select,
+.super-admin__actions button {
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.super-admin__actions select {
+  background-color: #fff;
+  color: #1b2559;
+}
+
+.super-admin__actions button {
+  background-color: #3b82f6;
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.25);
+}
+
+.super-admin__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.stat-card {
+  background: #fff;
+  padding: 1.75rem;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 15px 35px rgba(27, 37, 89, 0.08);
+}
+
+.stat-card h3 {
+  color: #6b7280;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stat-card__value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1b2559;
+}
+
+.stat-card__trend {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.stat-card__trend.up {
+  color: #22c55e;
+}
+
+.stat-card__trend.down {
+  color: #ef4444;
+}
+
+.super-admin__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 15px 35px rgba(27, 37, 89, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel__header h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1b2559;
+}
+
+.panel__header button,
+.panel__filters button {
+  background: rgba(59, 130, 246, 0.1);
+  color: #1b2559;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.panel__header button:hover,
+.panel__filters button:hover,
+.panel__filters button.active {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.panel--chart {
+  grid-column: span 2;
+}
+
+.chart {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  align-items: end;
+  gap: 1.5rem;
+  height: 200px;
+}
+
+.chart__column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chart__bar {
+  width: 100%;
+  background: linear-gradient(180deg, #3b82f6 0%, #2563eb 100%);
+  border-radius: 14px 14px 0 0;
+  min-height: 40px;
+  transition: transform 0.2s ease;
+}
+
+.chart__bar:hover {
+  transform: translateY(-5px);
+}
+
+.chart__label {
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.ranking {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ranking li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.ranking strong {
+  font-size: 1.05rem;
+  color: #1b2559;
+}
+
+.trend.up {
+  color: #22c55e;
+  font-weight: 600;
+}
+
+.panel--table .panel__header {
+  flex-wrap: wrap;
+}
+
+.panel__filters {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(27, 37, 89, 0.05);
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: #6b7280;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+tbody td {
+  padding: 0.9rem 0.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  color: #1b2559;
+  font-weight: 500;
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.table-actions button {
+  padding: 0.45rem 1rem;
+  border-radius: 10px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1b2559;
+  transition: background 0.2s ease;
+}
+
+.table-actions button:hover {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.table-actions .danger {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.table-actions .danger:hover {
+  background: #ef4444;
+  color: #fff;
+}
+
+.status {
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.status--active {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.status--pending {
+  background: rgba(250, 204, 21, 0.2);
+  color: #ca8a04;
+}
+
+.status--locked,
+.status--maintenance {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.status--delivering {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.status--available {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.battery {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.battery__bar {
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #22c55e, #16a34a);
+}
+
+@media (max-width: 1024px) {
+  .super-admin {
+    padding: 2rem 1.5rem 2.5rem;
+  }
+
+  .panel--chart {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .super-admin__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .super-admin__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .chart {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    height: 180px;
+  }
+
+  .table-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/SuperAdmin/SuperAdmin.jsx
+++ b/frontend/src/pages/SuperAdmin/SuperAdmin.jsx
@@ -1,0 +1,279 @@
+import React from 'react'
+import './SuperAdmin.css'
+
+const revenueByMonth = [
+  { month: 'Jan', revenue: 12000 },
+  { month: 'Feb', revenue: 14800 },
+  { month: 'Mar', revenue: 17150 },
+  { month: 'Apr', revenue: 16200 },
+  { month: 'May', revenue: 18900 },
+  { month: 'Jun', revenue: 21350 },
+]
+
+const topRestaurants = [
+  { name: 'Saigon Bistro', orders: 980, growth: '+12%' },
+  { name: 'Pho 24/7', orders: 860, growth: '+8%' },
+  { name: 'Banh Mi Corner', orders: 795, growth: '+6%' },
+]
+
+const topUsers = [
+  { name: 'Nguyen Van A', orders: 52, spend: '21.5M ₫' },
+  { name: 'Tran Thi B', orders: 47, spend: '19.8M ₫' },
+  { name: 'Le Quang C', orders: 39, spend: '16.2M ₫' },
+]
+
+const restaurants = [
+  { id: 'RES-1024', name: 'Hue Flavors', owner: 'Pham Thi Lan', status: 'Pending' },
+  { id: 'RES-2048', name: 'Saigon Bistro', owner: 'Le Hoang', status: 'Active' },
+  { id: 'RES-4096', name: 'Da Lat Garden', owner: 'Nguyen Thanh', status: 'Locked' },
+]
+
+const accounts = [
+  { id: 'USR-5588', name: 'Nguyen Van A', role: 'User', status: 'Active' },
+  { id: 'USR-8821', name: 'Tran Thi B', role: 'User', status: 'Locked' },
+  { id: 'RES-2048', name: 'Saigon Bistro', role: 'Restaurant', status: 'Active' },
+  { id: 'RES-1100', name: 'Pho Dakao', role: 'Restaurant', status: 'Pending' },
+]
+
+const drones = [
+  { id: 'DR-01', status: 'Available', battery: 92, notes: 'Ready for dispatch' },
+  { id: 'DR-02', status: 'Delivering', battery: 56, notes: 'Order #4581' },
+  { id: 'DR-03', status: 'Maintenance', battery: 18, notes: 'Rotor replacement required' },
+  { id: 'DR-04', status: 'Delivering', battery: 63, notes: 'Order #4589' },
+]
+
+const SuperAdmin = () => {
+  return (
+    <div className="super-admin">
+      <header className="super-admin__header">
+        <div>
+          <h1>Super Admin Dashboard</h1>
+          <p>Quản trị toàn bộ hệ thống FoodFast Delivery</p>
+        </div>
+        <div className="super-admin__actions">
+          <select aria-label="Chọn phạm vi thống kê">
+            <option>6 tháng gần nhất</option>
+            <option>12 tháng</option>
+            <option>Năm nay</option>
+          </select>
+          <button type="button">Xuất báo cáo</button>
+        </div>
+      </header>
+
+      <section className="super-admin__stats">
+        <article className="stat-card">
+          <h3>Tổng doanh thu</h3>
+          <p className="stat-card__value">124.5M ₫</p>
+          <span className="stat-card__trend up">+14% so với tháng trước</span>
+        </article>
+        <article className="stat-card">
+          <h3>Tổng số đơn</h3>
+          <p className="stat-card__value">4,892</p>
+          <span className="stat-card__trend up">+8% so với tháng trước</span>
+        </article>
+        <article className="stat-card">
+          <h3>Nhà hàng đang hoạt động</h3>
+          <p className="stat-card__value">126</p>
+          <span className="stat-card__trend">12 đang chờ duyệt</span>
+        </article>
+        <article className="stat-card">
+          <h3>Drone khả dụng</h3>
+          <p className="stat-card__value">14</p>
+          <span className="stat-card__trend down">3 cần bảo trì</span>
+        </article>
+      </section>
+
+      <section className="super-admin__grid">
+        <article className="panel panel--chart">
+          <div className="panel__header">
+            <h2>Doanh thu theo tháng</h2>
+            <span>VND</span>
+          </div>
+          <div className="chart">
+            {revenueByMonth.map((item) => (
+              <div key={item.month} className="chart__column">
+                <div
+                  className="chart__bar"
+                  style={{ height: `${item.revenue / 250}px` }}
+                  aria-label={`Doanh thu tháng ${item.month}: ${item.revenue.toLocaleString('vi-VN')} ₫`}
+                />
+                <span className="chart__label">{item.month}</span>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        <article className="panel">
+          <div className="panel__header">
+            <h2>Top nhà hàng</h2>
+            <button type="button">Xem tất cả</button>
+          </div>
+          <ul className="ranking">
+            {topRestaurants.map((restaurant) => (
+              <li key={restaurant.name}>
+                <div>
+                  <strong>{restaurant.name}</strong>
+                  <span>{restaurant.orders} đơn</span>
+                </div>
+                <span className="trend up">{restaurant.growth}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="panel">
+          <div className="panel__header">
+            <h2>Top người dùng</h2>
+            <button type="button">Xem tất cả</button>
+          </div>
+          <ul className="ranking">
+            {topUsers.map((user) => (
+              <li key={user.name}>
+                <div>
+                  <strong>{user.name}</strong>
+                  <span>{user.orders} đơn · {user.spend}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      <section className="super-admin__grid">
+        <article className="panel panel--table">
+          <div className="panel__header">
+            <h2>Quản lý nhà hàng</h2>
+            <div className="panel__filters">
+              <button type="button" className="active">Tất cả</button>
+              <button type="button">Chờ duyệt</button>
+              <button type="button">Đang khóa</button>
+            </div>
+          </div>
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Mã</th>
+                  <th>Tên nhà hàng</th>
+                  <th>Chủ sở hữu</th>
+                  <th>Trạng thái</th>
+                  <th>Hành động</th>
+                </tr>
+              </thead>
+              <tbody>
+                {restaurants.map((restaurant) => (
+                  <tr key={restaurant.id}>
+                    <td>{restaurant.id}</td>
+                    <td>{restaurant.name}</td>
+                    <td>{restaurant.owner}</td>
+                    <td>
+                      <span className={`status status--${restaurant.status.toLowerCase()}`}>
+                        {restaurant.status}
+                      </span>
+                    </td>
+                    <td className="table-actions">
+                      <button type="button">Duyệt</button>
+                      <button type="button" className="danger">Khóa</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+
+        <article className="panel panel--table">
+          <div className="panel__header">
+            <h2>Quản lý tài khoản</h2>
+            <div className="panel__filters">
+              <button type="button" className="active">Tất cả</button>
+              <button type="button">Người dùng</button>
+              <button type="button">Nhà hàng</button>
+            </div>
+          </div>
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Mã</th>
+                  <th>Tên</th>
+                  <th>Vai trò</th>
+                  <th>Trạng thái</th>
+                  <th>Hành động</th>
+                </tr>
+              </thead>
+              <tbody>
+                {accounts.map((account) => (
+                  <tr key={account.id}>
+                    <td>{account.id}</td>
+                    <td>{account.name}</td>
+                    <td>{account.role}</td>
+                    <td>
+                      <span className={`status status--${account.status.toLowerCase()}`}>
+                        {account.status}
+                      </span>
+                    </td>
+                    <td className="table-actions">
+                      <button type="button">Mở khóa</button>
+                      <button type="button" className="danger">Khóa</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      </section>
+
+      <section className="panel panel--table">
+        <div className="panel__header">
+          <h2>Quản lý drone</h2>
+          <div className="panel__filters">
+            <button type="button" className="active">Tất cả</button>
+            <button type="button">Đang hoạt động</button>
+            <button type="button">Rảnh</button>
+            <button type="button">Bảo trì</button>
+          </div>
+        </div>
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Mã drone</th>
+                <th>Trạng thái</th>
+                <th>Mức pin</th>
+                <th>Ghi chú</th>
+                <th>Hành động</th>
+              </tr>
+            </thead>
+            <tbody>
+              {drones.map((drone) => (
+                <tr key={drone.id}>
+                  <td>{drone.id}</td>
+                  <td>
+                    <span className={`status status--${drone.status.toLowerCase()}`}>
+                      {drone.status}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="battery">
+                      <div className="battery__bar" style={{ width: `${drone.battery}%` }} />
+                      <span>{drone.battery}%</span>
+                    </div>
+                  </td>
+                  <td>{drone.notes}</td>
+                  <td className="table-actions">
+                    <button type="button">Chi tiết</button>
+                    <button type="button" className="danger">Bảo trì</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default SuperAdmin


### PR DESCRIPTION
## Summary
- add a dedicated super admin dashboard page with statistics, charts, and management tables for restaurants, accounts, and drones
- hide the default navigation/footer on the super admin route and expand the layout to fill the viewport
- style the dashboard to present metrics, rankings, and operational tables in a cohesive layout

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b49d907083238994cdcd3cf6416d)