### PR TITLE
feat: implement mobile authentication flow

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import AppNavigator from './src/navigation/AppNavigator';
+import { AuthProvider } from './src/context/AuthContext';
 
 const App: React.FC = () => {
-  return <AppNavigator />;
+  return (
+    <AuthProvider>
+      <AppNavigator />
+    </AuthProvider>
+  );
 };
 
 export default App;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.10.0",
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "expo": "^54.0.23",
     "expo-status-bar": "~3.0.8",
     "react": "^19.1.0",

--- a/mobile/src/components/HeaderBar.tsx
+++ b/mobile/src/components/HeaderBar.tsx
@@ -1,14 +1,40 @@
-import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import colors from '../theme/colors';
 import spacing from '../theme/spacing';
+import { useAuth } from '../context/AuthContext';
+import { RootStackParamList } from '../navigation/AppNavigator';
 
 export type HeaderBarProps = {
   title?: string;
   onBackPress?: () => void;
+  showAuthControls?: boolean;
 };
 
-const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress }: HeaderBarProps) => {
+const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress, showAuthControls = true }) => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { user, logout } = useAuth();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleAuthPress = useCallback(async () => {
+    if (user) {
+      try {
+        setIsProcessing(true);
+        await logout();
+      } catch (error) {
+        console.warn('Không thể đăng xuất người dùng', error);
+      } finally {
+        setIsProcessing(false);
+      }
+    } else {
+      navigation.navigate('Auth');
+    }
+  }, [logout, navigation, user]);
+
+  const displayName = user?.username || user?.email;
+
   return (
     <View style={styles.container}>
       {onBackPress ? (
@@ -16,10 +42,40 @@ const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress }: HeaderBarPr
           <Text style={styles.backLabel}>←</Text>
         </TouchableOpacity>
       ) : (
-        <View style={styles.placeholder} />
+        <View style={styles.sidePlaceholder} />
       )}
       <Text style={styles.title}>{title ?? 'FoodFast'}</Text>
-      <View style={styles.placeholder} />
+      <View style={styles.actionContainer}>
+        {showAuthControls ? (
+          user ? (
+            <View style={styles.authRow}>
+              {displayName ? (
+                <Text style={styles.userLabel} numberOfLines={1}>
+                  {displayName}
+                </Text>
+              ) : null}
+              <TouchableOpacity
+                onPress={handleAuthPress}
+                style={[styles.authButton, isProcessing && styles.authButtonDisabled]}
+                activeOpacity={0.85}
+                disabled={isProcessing}
+              >
+                {isProcessing ? <ActivityIndicator size="small" color="#fff" /> : <Text style={styles.authButtonText}>Đăng xuất</Text>}
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <TouchableOpacity
+              onPress={handleAuthPress}
+              style={styles.authButton}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.authButtonText}>Đăng nhập</Text>
+            </TouchableOpacity>
+          )
+        ) : (
+          <View style={styles.sidePlaceholder} />
+        )}
+      </View>
     </View>
   );
 };
@@ -45,13 +101,45 @@ const styles = StyleSheet.create({
     color: colors.primary,
     fontWeight: '700',
   },
-  placeholder: {
+  sidePlaceholder: {
     width: 40,
   },
   title: {
+    flex: 1,
     fontSize: 20,
     fontWeight: '700',
     color: colors.text,
+    textAlign: 'center',
+  },
+  actionContainer: {
+    minWidth: 40,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  authRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  userLabel: {
+    color: colors.muted,
+    marginRight: spacing.xs,
+    maxWidth: 140,
+  },
+  authButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 20,
+    minWidth: 90,
+    alignItems: 'center',
+  },
+  authButtonDisabled: {
+    opacity: 0.8,
+  },
+  authButtonText: {
+    color: '#fff',
+    fontWeight: '700',
   },
 });
 

--- a/mobile/src/constants/api.ts
+++ b/mobile/src/constants/api.ts
@@ -1,0 +1,22 @@
+const env = (
+  (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+);
+
+const fallbackBaseUrl = 'http://localhost:5173/api';
+
+const normalizeBaseUrl = (url: string): string => {
+  if (!url) {
+    return fallbackBaseUrl;
+  }
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+};
+
+const resolveBaseUrl = (): string => {
+  const candidate = env.EXPO_PUBLIC_AUTH_API_BASE_URL ?? env.AUTH_API_BASE_URL ?? fallbackBaseUrl;
+  return normalizeBaseUrl(candidate);
+};
+
+export const API_BASE_URL = resolveBaseUrl();
+export const USERS_API_URL = `${API_BASE_URL}/users`;
+
+export const AUTH_USER_STORAGE_KEY = '@foodfast/user';

--- a/mobile/src/context/AuthContext.tsx
+++ b/mobile/src/context/AuthContext.tsx
@@ -1,0 +1,164 @@
+import React, { createContext, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AUTH_USER_STORAGE_KEY, USERS_API_URL } from '../constants/api';
+
+type StoredUser = {
+  id: number | string;
+  username?: string;
+  email: string;
+  password?: string;
+  [key: string]: unknown;
+};
+
+type RegisterPayload = {
+  username: string;
+  email: string;
+  password: string;
+};
+
+type AuthContextValue = {
+  user: StoredUser | null;
+  initializing: boolean;
+  login: (email: string, password: string) => Promise<StoredUser>;
+  register: (payload: RegisterPayload) => Promise<StoredUser>;
+  logout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const parseStoredUser = (value: string | null): StoredUser | null => {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as StoredUser;
+    }
+    return null;
+  } catch (error) {
+    console.warn('Không thể phân tích dữ liệu người dùng đã lưu', error);
+    return null;
+  }
+};
+
+const fetchUsers = async (): Promise<StoredUser[]> => {
+  const response = await fetch(USERS_API_URL);
+  if (!response.ok) {
+    throw new Error('Không thể giao tiếp với server');
+  }
+
+  try {
+    const data = await response.json();
+    return Array.isArray(data) ? (data as StoredUser[]) : [];
+  } catch (error) {
+    console.warn('Không thể phân tích danh sách người dùng', error);
+    return [];
+  }
+};
+
+export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [user, setUser] = useState<StoredUser | null>(null);
+  const [initializing, setInitializing] = useState<boolean>(true);
+
+  useEffect(() => {
+    const loadStoredUser = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(AUTH_USER_STORAGE_KEY);
+        const parsed = parseStoredUser(stored);
+        if (parsed) {
+          setUser(parsed);
+        }
+      } catch (error) {
+        console.warn('Không thể tải thông tin người dùng đã lưu', error);
+      } finally {
+        setInitializing(false);
+      }
+    };
+
+    loadStoredUser();
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const trimmedEmail = email.trim().toLowerCase();
+    if (!trimmedEmail || !password) {
+      throw new Error('Vui lòng nhập email và mật khẩu');
+    }
+
+    const users = await fetchUsers();
+    const matched = users.find(
+      (item) => item.email?.toLowerCase() === trimmedEmail && item.password === password
+    );
+
+    if (!matched) {
+      throw new Error('Thông tin đăng nhập không chính xác');
+    }
+
+    setUser(matched);
+    await AsyncStorage.setItem(AUTH_USER_STORAGE_KEY, JSON.stringify(matched));
+    return matched;
+  }, []);
+
+  const register = useCallback(async ({ username, email, password }: RegisterPayload) => {
+    const trimmedEmail = email.trim().toLowerCase();
+
+    if (!username || !trimmedEmail || !password) {
+      throw new Error('Vui lòng nhập đầy đủ và chính xác thông tin');
+    }
+
+    const users = await fetchUsers();
+    const existed = users.some((item) => item.email?.toLowerCase() === trimmedEmail);
+
+    if (existed) {
+      throw new Error('Email đã tồn tại');
+    }
+
+    const response = await fetch(USERS_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, email: trimmedEmail, password }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Không thể tạo tài khoản mới');
+    }
+
+    const created = (await response.json()) as StoredUser;
+    return created;
+  }, []);
+
+  const logout = useCallback(async () => {
+    setUser(null);
+    try {
+      await AsyncStorage.removeItem(AUTH_USER_STORAGE_KEY);
+    } catch (error) {
+      console.warn('Không thể xoá thông tin người dùng đã lưu', error);
+    }
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    try {
+      const stored = await AsyncStorage.getItem(AUTH_USER_STORAGE_KEY);
+      const parsed = parseStoredUser(stored);
+      setUser(parsed);
+    } catch (error) {
+      console.warn('Không thể làm mới thông tin người dùng đã lưu', error);
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ user, initializing, login, register, logout, refreshUser }),
+    [user, initializing, login, register, logout, refreshUser]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth phải được sử dụng trong AuthProvider');
+  }
+  return context;
+};

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import HomeScreen from '../screen/HomeScreen';
 import FoodDetailScreen from '../screen/FoodDetailScreen';
 import ContactScreen from '../screen/ContactScreen';
 import TrackingScreen from '../screen/TrackingScreen';
+import AuthScreen from '../screen/AuthScreen';
+import { useAuth } from '../context/AuthContext';
+import colors from '../theme/colors';
 
 export type RootStackParamList = {
+  Auth: undefined;
   Home: undefined;
   FoodDetail: { id: string } | undefined;
   Contact: undefined;
@@ -16,21 +21,52 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 const AppNavigator: React.FC = () => {
+  const { user, initializing } = useAuth();
+
+  if (initializing) {
+    return (
+      <NavigationContainer>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+          <Text style={styles.loadingText}>Đang tải...</Text>
+        </View>
+      </NavigationContainer>
+    );
+  }
+
   return (
     <NavigationContainer>
       <Stack.Navigator
-        initialRouteName="Home"
         screenOptions={{
           headerShown: false,
         }}
       >
-        <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="FoodDetail" component={FoodDetailScreen} />
-        <Stack.Screen name="Contact" component={ContactScreen} />
-        <Stack.Screen name="Tracking" component={TrackingScreen} />
+        {user ? (
+          <>
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="FoodDetail" component={FoodDetailScreen} />
+            <Stack.Screen name="Contact" component={ContactScreen} />
+            <Stack.Screen name="Tracking" component={TrackingScreen} />
+          </>
+        ) : (
+          <Stack.Screen name="Auth" component={AuthScreen} />
+        )}
       </Stack.Navigator>
     </NavigationContainer>
   );
 };
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+  },
+  loadingText: {
+    marginTop: 12,
+    color: colors.muted,
+  },
+});
 
 export default AppNavigator;

--- a/mobile/src/screen/AuthScreen.tsx
+++ b/mobile/src/screen/AuthScreen.tsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import ScreenContainer from '../components/ScreenContainer';
+import colors from '../theme/colors';
+import spacing from '../theme/spacing';
+import { useAuth } from '../context/AuthContext';
+
+const AuthScreen: React.FC = () => {
+  const { login, register } = useAuth();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const resetMessages = useCallback(() => {
+    setError(null);
+    setSuccess(null);
+  }, []);
+
+  const handleToggleMode = useCallback(
+    (nextMode: 'login' | 'register') => {
+      setMode(nextMode);
+      resetMessages();
+      if (nextMode === 'login') {
+        setConfirmPassword('');
+      }
+    },
+    [resetMessages]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    resetMessages();
+    setLoading(true);
+
+    try {
+      if (mode === 'login') {
+        await login(email, password);
+        setSuccess('Đăng nhập thành công');
+      } else {
+        if (password !== confirmPassword) {
+          throw new Error('Mật khẩu xác nhận không khớp');
+        }
+        await register({ username: username.trim(), email, password });
+        setMode('login');
+        setSuccess('Đăng ký thành công — hãy đăng nhập');
+        setEmail('');
+        setUsername('');
+        setPassword('');
+        setConfirmPassword('');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Đã xảy ra lỗi không mong muốn';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [confirmPassword, email, login, mode, password, register, resetMessages, username]);
+
+  return (
+    <ScreenContainer>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 32 : 0}
+      >
+        <ScrollView
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.card}>
+            <Text style={styles.title}>{mode === 'login' ? 'Đăng nhập' : 'Đăng ký'}</Text>
+            <View style={styles.switcher}>
+              <TouchableOpacity
+                style={[styles.switchButton, mode === 'login' && styles.switchButtonActive]}
+                onPress={() => handleToggleMode('login')}
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.switchLabel, mode === 'login' && styles.switchLabelActive]}>Đăng nhập</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.switchButton, mode === 'register' && styles.switchButtonActive]}
+                onPress={() => handleToggleMode('register')}
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.switchLabel, mode === 'register' && styles.switchLabelActive]}>Đăng ký</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.form}>
+              {mode === 'register' && (
+                <View style={styles.field}>
+                  <Text style={styles.label}>Tên người dùng</Text>
+                  <TextInput
+                    value={username}
+                    onChangeText={setUsername}
+                    placeholder="Nhập tên người dùng"
+                    style={styles.input}
+                    placeholderTextColor={colors.muted}
+                  />
+                </View>
+              )}
+
+              <View style={styles.field}>
+                <Text style={styles.label}>Email</Text>
+                <TextInput
+                  value={email}
+                  onChangeText={setEmail}
+                  placeholder="Nhập email"
+                  style={styles.input}
+                  autoCapitalize="none"
+                  keyboardType="email-address"
+                  placeholderTextColor={colors.muted}
+                />
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>Mật khẩu</Text>
+                <TextInput
+                  value={password}
+                  onChangeText={setPassword}
+                  placeholder="Nhập mật khẩu"
+                  style={styles.input}
+                  secureTextEntry
+                  placeholderTextColor={colors.muted}
+                />
+              </View>
+
+              {mode === 'register' && (
+                <View style={styles.field}>
+                  <Text style={styles.label}>Xác nhận mật khẩu</Text>
+                  <TextInput
+                    value={confirmPassword}
+                    onChangeText={setConfirmPassword}
+                    placeholder="Nhập lại mật khẩu"
+                    style={styles.input}
+                    secureTextEntry
+                    placeholderTextColor={colors.muted}
+                  />
+                </View>
+              )}
+
+              {error && <Text style={styles.error}>{error}</Text>}
+              {success && <Text style={styles.success}>{success}</Text>}
+
+              <TouchableOpacity
+                style={[styles.submitButton, loading && styles.submitButtonDisabled]}
+                onPress={handleSubmit}
+                disabled={loading}
+                activeOpacity={0.85}
+              >
+                {loading ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={styles.submitLabel}>{mode === 'login' ? 'Đăng nhập' : 'Đăng ký'}</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  container: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xl,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 32,
+    padding: spacing.xl,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 20,
+    elevation: 6,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: colors.text,
+    textAlign: 'center',
+  },
+  switcher: {
+    flexDirection: 'row',
+    marginTop: spacing.lg,
+    backgroundColor: '#F4F5FC',
+    borderRadius: 24,
+    padding: 4,
+  },
+  switchButton: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    borderRadius: 20,
+    alignItems: 'center',
+  },
+  switchButtonActive: {
+    backgroundColor: colors.primary,
+  },
+  switchLabel: {
+    fontWeight: '600',
+    color: colors.muted,
+  },
+  switchLabelActive: {
+    color: '#fff',
+  },
+  form: {
+    marginTop: spacing.lg,
+  },
+  field: {
+    marginBottom: spacing.md,
+  },
+  label: {
+    marginBottom: spacing.xs,
+    fontWeight: '600',
+    color: colors.muted,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 16,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: '#F9FAFF',
+    color: colors.text,
+  },
+  error: {
+    color: '#D64545',
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  success: {
+    color: colors.success,
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  submitButton: {
+    marginTop: spacing.sm,
+    backgroundColor: colors.primary,
+    borderRadius: 24,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  submitButtonDisabled: {
+    opacity: 0.7,
+  },
+  submitLabel: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+});
+
+export default AuthScreen;


### PR DESCRIPTION
## Summary
- add an authentication context backed by AsyncStorage and shared API constants
- introduce a dedicated mobile auth screen mirroring the web login/registration behaviour
- gate the app navigator and header on auth state with login/logout controls

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e396ab448323b58bd1ab231ba097)