### PR TITLE
Add mobile cart and drone checkout screens

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import AppNavigator from './src/navigation/AppNavigator';
 import { AuthProvider } from './src/context/AuthContext';
+import { CartProvider } from './src/context/CartContext';
 
 const App: React.FC = () => {
   return (
     <AuthProvider>
-      <AppNavigator />
+      <CartProvider>
+        <AppNavigator />
+      </CartProvider>
     </AuthProvider>
   );
 };

--- a/mobile/src/components/HeaderBar.tsx
+++ b/mobile/src/components/HeaderBar.tsx
@@ -6,16 +6,24 @@ import colors from '../theme/colors';
 import spacing from '../theme/spacing';
 import { useAuth } from '../context/AuthContext';
 import { RootStackParamList } from '../navigation/AppNavigator';
+import { useCart } from '../context/CartContext';
 
 export type HeaderBarProps = {
   title?: string;
   onBackPress?: () => void;
   showAuthControls?: boolean;
+  showCartButton?: boolean;
 };
 
-const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress, showAuthControls = true }) => {
+const HeaderBar: React.FC<HeaderBarProps> = ({
+  title,
+  onBackPress,
+  showAuthControls = true,
+  showCartButton = true,
+}) => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { user, logout } = useAuth();
+  const { totalItems } = useCart();
   const [isProcessing, setIsProcessing] = useState(false);
 
   const handleAuthPress = useCallback(async () => {
@@ -33,6 +41,10 @@ const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress, showAuthContr
     }
   }, [logout, navigation, user]);
 
+  const handleCartPress = useCallback(() => {
+    navigation.navigate('Cart');
+  }, [navigation]);
+
   const displayName = user?.username || user?.email;
 
   return (
@@ -46,6 +58,21 @@ const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress, showAuthContr
       )}
       <Text style={styles.title}>{title ?? 'FoodFast'}</Text>
       <View style={styles.actionContainer}>
+        {showCartButton ? (
+          <TouchableOpacity
+            onPress={handleCartPress}
+            style={styles.cartButton}
+            accessibilityRole="button"
+            activeOpacity={0.85}
+          >
+            <Text style={styles.cartIcon}>🛒</Text>
+            {totalItems > 0 ? (
+              <View style={styles.cartBadge}>
+                <Text style={styles.cartBadgeLabel}>{totalItems}</Text>
+              </View>
+            ) : null}
+          </TouchableOpacity>
+        ) : null}
         {showAuthControls ? (
           user ? (
             <View style={styles.authRow}>
@@ -72,9 +99,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({ title, onBackPress, showAuthContr
               <Text style={styles.authButtonText}>Đăng nhập</Text>
             </TouchableOpacity>
           )
-        ) : (
-          <View style={styles.sidePlaceholder} />
-        )}
+        ) : null}
       </View>
     </View>
   );
@@ -116,6 +141,35 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-end',
     alignItems: 'center',
+  },
+  cartButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    backgroundColor: '#F4F5FC',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm,
+  },
+  cartIcon: {
+    fontSize: 20,
+  },
+  cartBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    backgroundColor: colors.primary,
+    borderRadius: 10,
+    minWidth: 20,
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  cartBadgeLabel: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700',
   },
   authRow: {
     flexDirection: 'row',

--- a/mobile/src/context/CartContext.tsx
+++ b/mobile/src/context/CartContext.tsx
@@ -1,0 +1,103 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+import type { FoodItem } from '../data/menu';
+
+export type CartItem = FoodItem & {
+  quantity: number;
+};
+
+export type CartContextValue = {
+  items: CartItem[];
+  subtotal: number;
+  totalItems: number;
+  addItem: (item: FoodItem, quantity?: number) => void;
+  updateQuantity: (id: string, quantity: number) => void;
+  removeItem: (id: string) => void;
+  clearCart: () => void;
+};
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+export const CartProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addItem = useCallback((item: FoodItem, quantity = 1) => {
+    setItems((prev) => {
+      const existing = prev.find((entry) => entry.id === item.id);
+      if (existing) {
+        return prev.map((entry) =>
+          entry.id === item.id
+            ? {
+                ...entry,
+                quantity: entry.quantity + quantity,
+              }
+            : entry,
+        );
+      }
+      return [
+        ...prev,
+        {
+          ...item,
+          quantity,
+        },
+      ];
+    });
+  }, []);
+
+  const updateQuantity = useCallback((id: string, quantity: number) => {
+    setItems((prev) => {
+      if (quantity <= 0) {
+        return prev.filter((item) => item.id !== id);
+      }
+      return prev.map((item) => (item.id === id ? { ...item, quantity } : item));
+    });
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const clearCart = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const totalItems = useMemo(
+    () => items.reduce((total, item) => total + item.quantity, 0),
+    [items],
+  );
+
+  const subtotal = useMemo(
+    () => items.reduce((total, item) => total + item.price * item.quantity, 0),
+    [items],
+  );
+
+  const value = useMemo(
+    () => ({
+      items,
+      subtotal,
+      totalItems,
+      addItem,
+      updateQuantity,
+      removeItem,
+      clearCart,
+    }),
+    [items, subtotal, totalItems, addItem, updateQuantity, removeItem, clearCart],
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+};
+
+export const useCart = (): CartContextValue => {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error('useCart phải được sử dụng trong CartProvider');
+  }
+  return context;
+};
+

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -9,6 +9,8 @@ import TrackingScreen from '../screen/TrackingScreen';
 import AuthScreen from '../screen/AuthScreen';
 import { useAuth } from '../context/AuthContext';
 import colors from '../theme/colors';
+import CartScreen from '../screen/CartScreen';
+import CheckoutScreen from '../screen/CheckoutScreen';
 
 export type RootStackParamList = {
   Auth: undefined;
@@ -16,6 +18,8 @@ export type RootStackParamList = {
   FoodDetail: { id: string } | undefined;
   Contact: undefined;
   Tracking: undefined;
+  Cart: undefined;
+  Checkout: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -45,6 +49,8 @@ const AppNavigator: React.FC = () => {
           <>
             <Stack.Screen name="Home" component={HomeScreen} />
             <Stack.Screen name="FoodDetail" component={FoodDetailScreen} />
+            <Stack.Screen name="Cart" component={CartScreen} />
+            <Stack.Screen name="Checkout" component={CheckoutScreen} />
             <Stack.Screen name="Contact" component={ContactScreen} />
             <Stack.Screen name="Tracking" component={TrackingScreen} />
           </>

--- a/mobile/src/screen/CartScreen.tsx
+++ b/mobile/src/screen/CartScreen.tsx
@@ -1,0 +1,326 @@
+import React, { useMemo } from 'react';
+import {
+  FlatList,
+  Image,
+  ListRenderItem,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+ from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import ScreenContainer from '../components/ScreenContainer';
+import HeaderBar from '../components/HeaderBar';
+import colors from '../theme/colors';
+import spacing from '../theme/spacing';
+import { useCart, type CartItem } from '../context/CartContext';
+import type { RootStackParamList } from '../navigation/AppNavigator';
+
+const DELIVERY_FEE = 15000;
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Cart'>;
+
+const CartScreen: React.FC<Props> = ({ navigation }) => {
+  const { items, subtotal, updateQuantity, removeItem } = useCart();
+
+  const { deliveryFee, total } = useMemo(() => {
+    const fee = items.length > 0 ? DELIVERY_FEE : 0;
+    return {
+      deliveryFee: fee,
+      total: subtotal + fee,
+    };
+  }, [items.length, subtotal]);
+
+  const renderItem: ListRenderItem<CartItem> = ({ item }) => (
+    <View style={styles.itemCard}>
+      <View style={styles.itemRow}>
+        <Image source={{ uri: item.image }} style={styles.itemImage} />
+        <View style={styles.itemDetails}>
+          <Text style={styles.itemName}>{item.name}</Text>
+          <Text style={styles.itemCategory}>{item.category}</Text>
+          <Text style={styles.itemPrice}>{item.price.toLocaleString('vi-VN')}₫</Text>
+        </View>
+        <View style={styles.quantityControls}>
+          <TouchableOpacity
+            onPress={() => updateQuantity(item.id, item.quantity - 1)}
+            style={[styles.quantityButton, styles.quantityButtonGhost]}
+            accessibilityLabel={`Giảm ${item.name}`}
+          >
+            <Text style={styles.quantityButtonLabel}>-</Text>
+          </TouchableOpacity>
+          <Text style={styles.quantityValue}>{item.quantity}</Text>
+          <TouchableOpacity
+            onPress={() => updateQuantity(item.id, item.quantity + 1)}
+            style={styles.quantityButton}
+            accessibilityLabel={`Tăng ${item.name}`}
+          >
+            <Text style={[styles.quantityButtonLabel, styles.quantityButtonLabelDark]}>+</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      <View style={styles.itemFooter}>
+        <Text style={styles.itemSubtotalLabel}>Thành tiền</Text>
+        <View style={styles.itemFooterActions}>
+          <Text style={styles.itemSubtotalValue}>
+            {(item.price * item.quantity).toLocaleString('vi-VN')}₫
+          </Text>
+          <TouchableOpacity
+            onPress={() => removeItem(item.id)}
+            style={styles.removeButton}
+            accessibilityLabel={`Xóa ${item.name} khỏi giỏ hàng`}
+          >
+            <Text style={styles.removeButtonLabel}>Xóa</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+
+  const keyExtractor = (item: CartItem) => item.id;
+
+  const handleCheckout = () => {
+    if (!items.length) {
+      return;
+    }
+    navigation.navigate('Checkout');
+  };
+
+  return (
+    <ScreenContainer>
+      <HeaderBar
+        title="Giỏ hàng"
+        onBackPress={() => navigation.goBack()}
+        showAuthControls={false}
+        showCartButton={false}
+      />
+      {items.length === 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>Giỏ hàng của bạn đang trống</Text>
+          <Text style={styles.emptySubtitle}>
+            Thêm những món yêu thích để bắt đầu đơn hàng đầu tiên ngay hôm nay.
+          </Text>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('Home')}
+            style={styles.emptyCta}
+            activeOpacity={0.85}
+          >
+            <Text style={styles.emptyCtaLabel}>Khám phá thực đơn</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+          ListFooterComponent={
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryTitle}>Tổng kết đơn hàng</Text>
+              <View style={styles.summaryRow}>
+                <Text style={styles.summaryLabel}>Tạm tính</Text>
+                <Text style={styles.summaryValue}>{subtotal.toLocaleString('vi-VN')}₫</Text>
+              </View>
+              <View style={styles.summaryRow}>
+                <Text style={styles.summaryLabel}>Phí giao drone</Text>
+                <Text style={styles.summaryValue}>
+                  {deliveryFee > 0 ? `${deliveryFee.toLocaleString('vi-VN')}₫` : 'Miễn phí'}
+                </Text>
+              </View>
+              <View style={[styles.summaryRow, styles.summaryRowTotal]}>
+                <Text style={styles.summaryTotalLabel}>Tổng cộng</Text>
+                <Text style={styles.summaryTotalValue}>{total.toLocaleString('vi-VN')}₫</Text>
+              </View>
+              <TouchableOpacity style={styles.checkoutButton} onPress={handleCheckout} activeOpacity={0.9}>
+                <Text style={styles.checkoutButtonLabel}>Tiến hành đặt drone</Text>
+              </TouchableOpacity>
+            </View>
+          }
+        />
+      )}
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingBottom: spacing.xxl,
+    paddingHorizontal: spacing.lg,
+  },
+  itemCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 28,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+  },
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  itemImage: {
+    width: 70,
+    height: 70,
+    borderRadius: 18,
+    marginRight: spacing.md,
+  },
+  itemDetails: {
+    flex: 1,
+  },
+  itemName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  itemCategory: {
+    color: colors.muted,
+    marginTop: 2,
+  },
+  itemPrice: {
+    marginTop: spacing.xs,
+    color: colors.primary,
+    fontWeight: '700',
+  },
+  quantityControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F4F5FC',
+    padding: spacing.xs,
+    borderRadius: 20,
+  },
+  quantityButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: '#FFE8DA',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  quantityButtonGhost: {
+    backgroundColor: '#fff',
+  },
+  quantityButtonLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.primary,
+  },
+  quantityButtonLabelDark: {
+    color: colors.primary,
+  },
+  quantityValue: {
+    marginHorizontal: spacing.sm,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  itemFooter: {
+    marginTop: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  itemFooterActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  itemSubtotalLabel: {
+    color: colors.muted,
+  },
+  itemSubtotalValue: {
+    fontWeight: '700',
+    color: colors.text,
+    marginRight: spacing.md,
+  },
+  removeButton: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    backgroundColor: '#FBE7E7',
+    borderRadius: 16,
+  },
+  removeButtonLabel: {
+    color: '#D14343',
+    fontWeight: '600',
+  },
+  summaryCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 32,
+    padding: spacing.xl,
+    marginTop: spacing.lg,
+    marginBottom: spacing.xxl,
+  },
+  summaryTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  summaryRowTotal: {
+    marginTop: spacing.md,
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: '#ECEFF8',
+  },
+  summaryLabel: {
+    color: colors.muted,
+  },
+  summaryValue: {
+    fontWeight: '600',
+    color: colors.text,
+  },
+  summaryTotalLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  summaryTotalValue: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: colors.primary,
+  },
+  checkoutButton: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    borderRadius: 28,
+    alignItems: 'center',
+  },
+  checkoutButtonLabel: {
+    color: '#fff',
+    fontWeight: '700',
+  },
+  emptyState: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: colors.text,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    marginTop: spacing.sm,
+    color: colors.muted,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  emptyCta: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+    borderRadius: 28,
+  },
+  emptyCtaLabel: {
+    color: '#fff',
+    fontWeight: '700',
+  },
+});
+
+export default CartScreen;

--- a/mobile/src/screen/CheckoutScreen.tsx
+++ b/mobile/src/screen/CheckoutScreen.tsx
@@ -1,0 +1,509 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import ScreenContainer from '../components/ScreenContainer';
+import HeaderBar from '../components/HeaderBar';
+import colors from '../theme/colors';
+import spacing from '../theme/spacing';
+import { useCart } from '../context/CartContext';
+import type { RootStackParamList } from '../navigation/AppNavigator';
+
+const DELIVERY_METHODS = [
+  {
+    key: 'drone',
+    label: 'Giao bằng drone',
+    icon: '🚁',
+    highlight: 'Nhanh nhất',
+    description: '10 - 15 phút, theo dõi trực tiếp',
+  },
+  {
+    key: 'motorbike',
+    label: 'Giao xe máy',
+    icon: '🛵',
+    highlight: 'Tiết kiệm',
+    description: '25 - 35 phút, phù hợp nội thành',
+  },
+] as const;
+
+type DeliveryMethodKey = (typeof DELIVERY_METHODS)[number]['key'];
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Checkout'>;
+
+type CheckoutForm = {
+  fullName: string;
+  phone: string;
+  address: string;
+  note: string;
+};
+
+const INITIAL_FORM: CheckoutForm = {
+  fullName: '',
+  phone: '',
+  address: '',
+  note: '',
+};
+
+const calculateDeliveryFee = (method: DeliveryMethodKey, subtotal: number) => {
+  if (subtotal <= 0) {
+    return 0;
+  }
+
+  if (method === 'drone') {
+    if (subtotal >= 150000) {
+      return 35000;
+    }
+    return 45000;
+  }
+
+  if (subtotal >= 120000) {
+    return 0;
+  }
+  return 15000;
+};
+
+const CheckoutScreen: React.FC<Props> = ({ navigation }) => {
+  const { items, subtotal, clearCart } = useCart();
+  const [form, setForm] = useState<CheckoutForm>(INITIAL_FORM);
+  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethodKey>('drone');
+
+  const deliveryFee = useMemo(() => calculateDeliveryFee(deliveryMethod, subtotal), [deliveryMethod, subtotal]);
+  const total = useMemo(() => subtotal + deliveryFee, [subtotal, deliveryFee]);
+
+  const handleChange = (field: keyof CheckoutForm, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handlePlaceOrder = () => {
+    if (!items.length) {
+      Alert.alert('Giỏ hàng trống', 'Hãy chọn món trước khi đặt drone nhé.');
+      return;
+    }
+
+    if (!form.fullName.trim() || !form.phone.trim() || !form.address.trim()) {
+      Alert.alert('Thiếu thông tin', 'Vui lòng nhập họ tên, số điện thoại và địa chỉ nhận hàng.');
+      return;
+    }
+
+    const orderCode = `FF-${Math.floor(1000 + Math.random() * 9000)}`;
+    const summary = `Đơn ${orderCode}\nTổng thanh toán: ${total.toLocaleString('vi-VN')}₫`;
+
+    Alert.alert('Đặt drone thành công', summary, [
+      {
+        text: 'Theo dõi lộ trình',
+        onPress: () => {
+          clearCart();
+          navigation.navigate('Tracking');
+        },
+      },
+      {
+        text: 'Quay lại trang chủ',
+        style: 'cancel',
+        onPress: () => {
+          clearCart();
+          navigation.navigate('Home');
+        },
+      },
+    ]);
+  };
+
+  const renderOrderItems = () =>
+    items.map((item) => (
+      <View key={item.id} style={styles.orderItemRow}>
+        <View style={styles.orderItemInfo}>
+          <Text style={styles.orderItemQuantity}>{item.quantity}x</Text>
+          <Text style={styles.orderItemName}>{item.name}</Text>
+        </View>
+        <Text style={styles.orderItemPrice}>{(item.price * item.quantity).toLocaleString('vi-VN')}₫</Text>
+      </View>
+    ));
+
+  if (!items.length) {
+    return (
+      <ScreenContainer>
+        <HeaderBar title="Đặt drone" onBackPress={() => navigation.goBack()} showAuthControls={false} showCartButton={false} />
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>Bạn chưa có món nào trong giỏ.</Text>
+          <Text style={styles.emptySubtitle}>Hãy quay lại thực đơn và thêm món trước khi đặt drone nhé!</Text>
+          <TouchableOpacity onPress={() => navigation.navigate('Home')} style={styles.emptyCta} activeOpacity={0.85}>
+            <Text style={styles.emptyCtaLabel}>Khám phá thực đơn</Text>
+          </TouchableOpacity>
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  return (
+    <ScreenContainer>
+      <HeaderBar
+        title="Đặt drone"
+        onBackPress={() => navigation.goBack()}
+        showAuthControls={false}
+        showCartButton={false}
+      />
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <Text style={styles.sectionTitle}>Thông tin giao hàng</Text>
+        <View style={styles.formCard}>
+          <View style={styles.field}>
+            <Text style={styles.fieldLabel}>Họ và tên</Text>
+            <TextInput
+              value={form.fullName}
+              onChangeText={(value) => handleChange('fullName', value)}
+              placeholder="Nhập họ tên người nhận"
+              style={styles.input}
+              placeholderTextColor={colors.muted}
+            />
+          </View>
+          <View style={styles.fieldRow}>
+            <View style={[styles.field, styles.fieldHalf]}>
+              <Text style={styles.fieldLabel}>Số điện thoại</Text>
+              <TextInput
+                value={form.phone}
+                onChangeText={(value) => handleChange('phone', value)}
+                placeholder="Ví dụ: 0901 234 567"
+                style={styles.input}
+                keyboardType="phone-pad"
+                placeholderTextColor={colors.muted}
+              />
+            </View>
+            <View style={[styles.field, styles.fieldHalf]}>
+              <Text style={styles.fieldLabel}>Ghi chú</Text>
+              <TextInput
+                value={form.note}
+                onChangeText={(value) => handleChange('note', value)}
+                placeholder="Thời gian nhận, lưu ý..."
+                style={styles.input}
+                placeholderTextColor={colors.muted}
+              />
+            </View>
+          </View>
+          <View style={styles.field}>
+            <Text style={styles.fieldLabel}>Địa chỉ</Text>
+            <TextInput
+              value={form.address}
+              onChangeText={(value) => handleChange('address', value)}
+              placeholder="Số nhà, tên đường, phường/xã"
+              style={[styles.input, styles.inputMultiline]}
+              placeholderTextColor={colors.muted}
+              multiline
+            />
+          </View>
+        </View>
+
+        <Text style={styles.sectionTitle}>Chọn phương thức giao</Text>
+        <View style={styles.methodGrid}>
+          {DELIVERY_METHODS.map((method, index) => {
+            const isActive = method.key === deliveryMethod;
+            const isLast = index === DELIVERY_METHODS.length - 1;
+            return (
+              <TouchableOpacity
+                key={method.key}
+                style={[styles.methodCard, !isLast && styles.methodCardSpacing, isActive && styles.methodCardActive]}
+                onPress={() => setDeliveryMethod(method.key)}
+                activeOpacity={0.9}
+              >
+                <View style={styles.methodHeader}>
+                  <Text style={styles.methodIcon}>{method.icon}</Text>
+                  <View style={styles.methodHeaderText}>
+                    <Text style={styles.methodLabel}>{method.label}</Text>
+                    <Text style={styles.methodHighlight}>{method.highlight}</Text>
+                  </View>
+                </View>
+                <Text style={styles.methodDescription}>{method.description}</Text>
+                {isActive ? <Text style={styles.methodActiveBadge}>Đang chọn</Text> : null}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <View style={styles.mapCard}>
+          <Text style={styles.mapTitle}>Lộ trình bay dự kiến</Text>
+          <Text style={styles.mapDescription}>
+            Drone sẽ khởi hành từ bếp trung tâm và hạ cánh gần địa chỉ {form.address || 'của bạn'}.
+            Bạn có thể theo dõi trạng thái từng giai đoạn ngay sau khi đặt hàng.
+          </Text>
+          <View style={styles.mapPlaceholder}>
+            <Text style={styles.mapPlaceholderLabel}>Bản đồ mô phỏng đường bay</Text>
+          </View>
+        </View>
+
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryTitle}>Tóm tắt đơn hàng</Text>
+          {renderOrderItems()}
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>Tạm tính</Text>
+            <Text style={styles.summaryValue}>{subtotal.toLocaleString('vi-VN')}₫</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>
+              {deliveryMethod === 'drone' ? 'Phí drone siêu tốc' : 'Phí giao tiêu chuẩn'}
+            </Text>
+            <Text style={styles.summaryValue}>{deliveryFee > 0 ? `${deliveryFee.toLocaleString('vi-VN')}₫` : 'Miễn phí'}</Text>
+          </View>
+          <View style={[styles.summaryRow, styles.summaryRowTotal]}>
+            <Text style={styles.summaryTotalLabel}>Tổng cộng</Text>
+            <Text style={styles.summaryTotalValue}>{total.toLocaleString('vi-VN')}₫</Text>
+          </View>
+          <TouchableOpacity style={styles.submitButton} onPress={handlePlaceOrder} activeOpacity={0.9}>
+            <Text style={styles.submitButtonLabel}>Đặt drone ngay</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    paddingBottom: spacing.xxl,
+    paddingHorizontal: spacing.lg,
+  },
+  sectionTitle: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  formCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 28,
+    padding: spacing.xl,
+    marginBottom: spacing.xl,
+  },
+  field: {
+    marginBottom: spacing.md,
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    marginHorizontal: -spacing.sm,
+  },
+  fieldHalf: {
+    flex: 1,
+    marginHorizontal: spacing.sm,
+  },
+  fieldLabel: {
+    color: colors.muted,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    backgroundColor: '#F4F5FC',
+    borderRadius: 18,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    color: colors.text,
+  },
+  inputMultiline: {
+    minHeight: 72,
+    textAlignVertical: 'top',
+  },
+  methodGrid: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xl,
+  },
+  methodCard: {
+    flex: 1,
+    backgroundColor: colors.surface,
+    borderRadius: 24,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: 'transparent',
+  },
+  methodCardSpacing: {
+    marginRight: spacing.md,
+  },
+  methodCardActive: {
+    borderColor: colors.primary,
+    shadowColor: colors.primary,
+    shadowOpacity: 0.15,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 20,
+    elevation: 6,
+  },
+  methodHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  methodHeaderText: {
+    marginLeft: spacing.sm,
+  },
+  methodIcon: {
+    fontSize: 24,
+  },
+  methodLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  methodHighlight: {
+    color: colors.accent,
+    marginTop: 2,
+    fontWeight: '600',
+  },
+  methodDescription: {
+    color: colors.muted,
+    lineHeight: 20,
+  },
+  methodActiveBadge: {
+    marginTop: spacing.sm,
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: 20,
+    backgroundColor: '#FFE8DA',
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  mapCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 28,
+    padding: spacing.xl,
+    marginBottom: spacing.xl,
+  },
+  mapTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  mapDescription: {
+    color: colors.muted,
+    lineHeight: 20,
+  },
+  mapPlaceholder: {
+    marginTop: spacing.md,
+    height: 160,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#E2E6F3',
+    backgroundColor: '#F4F6FF',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mapPlaceholderLabel: {
+    color: colors.accent,
+    fontWeight: '600',
+  },
+  summaryCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 32,
+    padding: spacing.xl,
+    marginBottom: spacing.xxl,
+  },
+  summaryTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  orderItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
+  orderItemInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  orderItemQuantity: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: '#F4F5FC',
+    textAlign: 'center',
+    textAlignVertical: 'center',
+    fontWeight: '700',
+    color: colors.primary,
+    marginRight: spacing.sm,
+  },
+  orderItemName: {
+    color: colors.text,
+    fontWeight: '600',
+    maxWidth: 180,
+  },
+  orderItemPrice: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: spacing.sm,
+  },
+  summaryRowTotal: {
+    marginTop: spacing.md,
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: '#ECEFF8',
+  },
+  summaryLabel: {
+    color: colors.muted,
+  },
+  summaryValue: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  summaryTotalLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  summaryTotalValue: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: colors.primary,
+  },
+  submitButton: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    borderRadius: 28,
+    alignItems: 'center',
+  },
+  submitButtonLabel: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  emptyState: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: colors.text,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    marginTop: spacing.sm,
+    color: colors.muted,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  emptyCta: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+    borderRadius: 28,
+  },
+  emptyCtaLabel: {
+    color: '#fff',
+    fontWeight: '700',
+  },
+});
+
+export default CheckoutScreen;

--- a/mobile/src/screen/FoodDetailScreen.tsx
+++ b/mobile/src/screen/FoodDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import ScreenContainer from '../components/ScreenContainer';
 import HeaderBar from '../components/HeaderBar';
@@ -8,6 +8,7 @@ import spacing from '../theme/spacing';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { featured, popular } from '../data/menu';
 import FoodCard from '../components/FoodCard';
+import { useCart } from '../context/CartContext';
 
 const allFood = [...featured, ...popular];
 
@@ -22,6 +23,15 @@ const FoodDetailScreen: React.FC<Props> = ({ route, navigation }) => {
   }, [route.params?.id]);
 
   const recommendations = useMemo(() => allFood.filter((item) => item.id !== selected.id).slice(0, 3), [selected.id]);
+  const { addItem } = useCart();
+
+  const handleAddToCart = () => {
+    addItem(selected);
+    Alert.alert('Thành công', `${selected.name} đã được thêm vào giỏ hàng.`, [
+      { text: 'Tiếp tục chọn món' },
+      { text: 'Xem giỏ hàng', onPress: () => navigation.navigate('Cart') },
+    ]);
+  };
 
   return (
     <ScreenContainer>
@@ -53,7 +63,7 @@ const FoodDetailScreen: React.FC<Props> = ({ route, navigation }) => {
               <Text style={styles.metaValue}>2 người</Text>
             </View>
           </View>
-          <TouchableOpacity style={styles.ctaButton} activeOpacity={0.9}>
+          <TouchableOpacity style={styles.ctaButton} activeOpacity={0.9} onPress={handleAddToCart}>
             <Text style={styles.ctaLabel}>Thêm vào giỏ hàng</Text>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
## Summary
- add a cart context provider so the mobile app can persist cart items and totals
- create cart and checkout screens tailored to the drone delivery flow and wire them into navigation
- update headers and food detail view to expose cart access and allow adding items

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130211af348323b3a9d14a3f912d30)