### PR TITLE
feat: add mobile account screen and refresh cart icon

### DIFF
--- a/mobile/src/components/HeaderBar.tsx
+++ b/mobile/src/components/HeaderBar.tsx
@@ -45,6 +45,10 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     navigation.navigate('Cart');
   }, [navigation]);
 
+  const handleAccountPress = useCallback(() => {
+    navigation.navigate('Account');
+  }, [navigation]);
+
   const displayName = user?.username || user?.email || '';
 
   return (
@@ -65,7 +69,13 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
             accessibilityRole="button"
             activeOpacity={0.85}
           >
-            <Text style={styles.cartIcon}>🛒</Text>
+            <View style={styles.cartIconWrapper}>
+              <View style={styles.cartHandle} />
+              <View style={styles.cartBasket}>
+                <View style={[styles.cartDivider, { left: 6 }]} />
+                <View style={[styles.cartDivider, { right: 6 }]} />
+              </View>
+            </View>
             {totalItems > 0 ? (
               <View style={styles.cartBadge}>
                 <Text style={styles.cartBadgeLabel}>{totalItems}</Text>
@@ -77,9 +87,16 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
           user ? (
             <View style={styles.authRow}>
               {displayName ? (
-                <Text style={styles.userLabel} numberOfLines={1}>
-                  {String(displayName)}
-                </Text>
+                <TouchableOpacity
+                  onPress={handleAccountPress}
+                  accessibilityRole="button"
+                  style={styles.userLabelButton}
+                  activeOpacity={0.85}
+                >
+                  <Text style={styles.userLabel} numberOfLines={1}>
+                    {String(displayName)}
+                  </Text>
+                </TouchableOpacity>
               ) : null}
               <TouchableOpacity
                 onPress={handleAuthPress}
@@ -153,8 +170,39 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginRight: spacing.sm,
   },
-  cartIcon: {
-    fontSize: 20,
+  cartIconWrapper: {
+    width: 22,
+    alignItems: 'center',
+  },
+  cartHandle: {
+    width: 16,
+    height: 8,
+    borderWidth: 1.6,
+    borderColor: colors.text,
+    borderBottomWidth: 0,
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+    marginBottom: -1,
+  },
+  cartBasket: {
+    width: 20,
+    height: 10,
+    borderWidth: 1.6,
+    borderColor: colors.text,
+    borderTopWidth: 1.1,
+    borderRadius: 4,
+    justifyContent: 'flex-end',
+    paddingBottom: 2,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  cartDivider: {
+    position: 'absolute',
+    top: 2,
+    bottom: 2,
+    width: 1.2,
+    backgroundColor: colors.text,
+    opacity: 0.85,
   },
   cartBadge: {
     position: 'absolute',
@@ -177,9 +225,15 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  userLabelButton: {
+    marginRight: spacing.xs,
+    paddingVertical: spacing.xs / 2,
+    paddingHorizontal: spacing.xs,
+    borderRadius: 14,
+    backgroundColor: 'transparent',
+  },
   userLabel: {
     color: colors.muted,
-    marginRight: spacing.xs,
     maxWidth: 140,
   },
   authButton: {

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -10,6 +10,8 @@ import {
   AuthScreen,
   CartScreen,
   CheckoutScreen,
+  AccountScreen,
+  OrderHistoryScreen,
 } from '../screen';
 import { useAuth } from '../context';
 import colors from '../theme/colors';
@@ -46,6 +48,8 @@ const AppNavigator: React.FC = () => {
             <Stack.Screen name="Checkout" component={CheckoutScreen} />
             <Stack.Screen name="Contact" component={ContactScreen} />
             <Stack.Screen name="Tracking" component={TrackingScreen} />
+            <Stack.Screen name="Account" component={AccountScreen} />
+            <Stack.Screen name="OrderHistory" component={OrderHistoryScreen} />
           </>
         ) : (
           <Stack.Screen name="Auth" component={AuthScreen} />

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -6,4 +6,6 @@ export type RootStackParamList = {
   Tracking: undefined;
   Cart: undefined;
   Checkout: undefined;
+  Account: undefined;
+  OrderHistory: undefined;
 };

--- a/mobile/src/screen/AccountScreen.tsx
+++ b/mobile/src/screen/AccountScreen.tsx
@@ -1,0 +1,155 @@
+import React, { useMemo } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import HeaderBar from '../components/HeaderBar';
+import colors from '../theme/colors';
+import spacing from '../theme/spacing';
+import shadows from '../theme/shadows';
+import { RootStackParamList } from '../navigation/types';
+import { useAuth } from '../context';
+
+const AccountScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { user } = useAuth();
+
+  const actions = useMemo(
+    () => [
+      {
+        key: 'tracking',
+        title: 'Theo dõi đơn hàng',
+        description: 'Kiểm tra trạng thái đơn hàng hiện tại của bạn theo thời gian thực.',
+        onPress: () => navigation.navigate('Tracking'),
+      },
+      {
+        key: 'history',
+        title: 'Lịch sử đặt món',
+        description: 'Xem lại các món ăn đã đặt và đặt lại chỉ với một chạm.',
+        onPress: () => navigation.navigate('OrderHistory'),
+      },
+    ],
+    [navigation],
+  );
+
+  const displayName = user?.username || user?.email || 'Người dùng FoodFast';
+
+  return (
+    <View style={styles.container}>
+      <HeaderBar title="Tài khoản" onBackPress={() => navigation.goBack()} />
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.profileCard}>
+          <View style={styles.avatarPlaceholder}>
+            <Text style={styles.avatarInitial}>{displayName.charAt(0).toUpperCase()}</Text>
+          </View>
+          <View style={styles.profileDetails}>
+            <Text style={styles.profileName}>{displayName}</Text>
+            {user?.email ? <Text style={styles.profileMeta}>{user.email}</Text> : null}
+          </View>
+        </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Tiện ích</Text>
+          {actions.map((action) => (
+            <TouchableOpacity
+              key={action.key}
+              style={styles.actionCard}
+              onPress={action.onPress}
+              activeOpacity={0.85}
+              accessibilityRole="button"
+            >
+              <View style={styles.actionContent}>
+                <Text style={styles.actionTitle}>{action.title}</Text>
+                <Text style={styles.actionDescription}>{action.description}</Text>
+              </View>
+              <Text style={styles.actionIndicator}>›</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    padding: spacing.lg,
+    paddingBottom: spacing.xxl,
+  },
+  profileCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    backgroundColor: colors.surface,
+    borderRadius: 24,
+    ...shadows.card,
+    marginBottom: spacing.xl,
+  },
+  avatarPlaceholder: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: '#FFE8DA',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.md,
+  },
+  avatarInitial: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.primary,
+  },
+  profileDetails: {
+    flex: 1,
+  },
+  profileName: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  profileMeta: {
+    marginTop: 4,
+    color: colors.muted,
+  },
+  section: {
+    marginBottom: spacing.xl,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  actionCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 20,
+    padding: spacing.lg,
+    marginBottom: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    ...shadows.card,
+  },
+  actionContent: {
+    flex: 1,
+    paddingRight: spacing.md,
+  },
+  actionTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: 6,
+  },
+  actionDescription: {
+    color: colors.muted,
+    lineHeight: 20,
+  },
+  actionIndicator: {
+    fontSize: 22,
+    color: colors.muted,
+  },
+});
+
+export default AccountScreen;

--- a/mobile/src/screen/OrderHistoryScreen.tsx
+++ b/mobile/src/screen/OrderHistoryScreen.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import HeaderBar from '../components/HeaderBar';
+import colors from '../theme/colors';
+import spacing from '../theme/spacing';
+import shadows from '../theme/shadows';
+import { RootStackParamList } from '../navigation/types';
+
+const ORDERS = [
+  {
+    id: 'FF-20240901',
+    date: '12/09/2024',
+    status: 'Hoàn thành',
+    statusColor: colors.success,
+    total: '185.000đ',
+    items: ['Bún bò Huế đặc biệt', 'Nước sâm bí đao'],
+  },
+  {
+    id: 'FF-20240817',
+    date: '28/08/2024',
+    status: 'Đang giao',
+    statusColor: colors.primary,
+    total: '132.000đ',
+    items: ['Cơm gà xối mỡ', 'Trà chanh mật ong'],
+  },
+  {
+    id: 'FF-20240802',
+    date: '05/08/2024',
+    status: 'Đã hủy',
+    statusColor: '#D62828',
+    total: '96.000đ',
+    items: ['Bánh mì đặc biệt', 'Cà phê sữa đá'],
+  },
+];
+
+const OrderHistoryScreen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  return (
+    <View style={styles.container}>
+      <HeaderBar title="Lịch sử đặt món" onBackPress={() => navigation.goBack()} />
+      <ScrollView contentContainerStyle={styles.content}>
+        {ORDERS.map((order) => (
+          <View key={order.id} style={styles.card}>
+            <View style={styles.cardHeader}>
+              <Text style={styles.orderId}>{order.id}</Text>
+              <Text style={[styles.orderStatus, { color: order.statusColor }]}>{order.status}</Text>
+            </View>
+            <Text style={styles.metaText}>Ngày đặt: {order.date}</Text>
+            <View style={styles.divider} />
+            <View style={styles.itemList}>
+              {order.items.map((item) => (
+                <Text key={item} style={styles.itemText}>
+                  • {item}
+                </Text>
+              ))}
+            </View>
+            <Text style={styles.totalLabel}>Tổng cộng: <Text style={styles.totalValue}>{order.total}</Text></Text>
+          </View>
+        ))}
+        <Text style={styles.helperText}>
+          Bạn có thể đặt lại món yêu thích từ danh sách này hoặc theo dõi đơn đang giao trong mục "Theo dõi đơn hàng".
+        </Text>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    padding: spacing.lg,
+    paddingBottom: spacing.xxl,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 20,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+    ...shadows.card,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  orderId: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  orderStatus: {
+    fontWeight: '700',
+  },
+  metaText: {
+    color: colors.muted,
+    marginBottom: spacing.sm,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginVertical: spacing.sm,
+  },
+  itemList: {
+    marginBottom: spacing.sm,
+  },
+  itemText: {
+    color: colors.text,
+    marginBottom: 4,
+  },
+  totalLabel: {
+    fontWeight: '600',
+    color: colors.text,
+  },
+  totalValue: {
+    color: colors.primary,
+  },
+  helperText: {
+    color: colors.muted,
+    textAlign: 'center',
+    lineHeight: 20,
+    marginTop: spacing.md,
+  },
+});
+
+export default OrderHistoryScreen;

--- a/mobile/src/screen/index.ts
+++ b/mobile/src/screen/index.ts
@@ -5,3 +5,5 @@ export { default as CheckoutScreen } from './CheckoutScreen';
 export { default as FoodDetailScreen } from './FoodDetailScreen';
 export { default as ContactScreen } from './ContactScreen';
 export { default as TrackingScreen } from './TrackingScreen';
+export { default as AccountScreen } from './AccountScreen';
+export { default as OrderHistoryScreen } from './OrderHistoryScreen';


### PR DESCRIPTION
## Summary
- restyle the cart button with a basket-shaped icon and link the username to the account area
- add a dedicated account screen that highlights tracking and order history utilities for signed-in users
- introduce a simple order history screen and register the new routes in the mobile navigator

## Testing
- not run (mobile)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133c78681083238d252faaef423559)